### PR TITLE
Deprecated getDataClient & createBulkMutation

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -334,11 +334,8 @@ public class BigtableSession implements Closeable {
   /**
    * <p>Getter for the field <code>dataClient</code>.</p>
    *
-   * @deprecated Please use {@link #getClientWrapper()}.
-   *
    * @return a {@link com.google.cloud.bigtable.grpc.BigtableDataClient} object.
    */
-  @Deprecated
   public BigtableDataClient getDataClient() {
     return dataClient;
   }
@@ -381,12 +378,9 @@ public class BigtableSession implements Closeable {
   /**
    * <p>createBulkMutation.</p>
    *
-   * @deprecated Please use {@link #createBulkMutationWrapper(BigtableTableName)}.
-   *
    * @param tableName a {@link com.google.cloud.bigtable.grpc.BigtableTableName} object.
    * @return a {@link com.google.cloud.bigtable.grpc.async.BulkMutation} object.
    */
-  @Deprecated
   public BulkMutation createBulkMutation(BigtableTableName tableName) {
     return new BulkMutation(
         tableName,

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -334,8 +334,11 @@ public class BigtableSession implements Closeable {
   /**
    * <p>Getter for the field <code>dataClient</code>.</p>
    *
+   * @deprecated Please use {@link #getClientWrapper()}.
+   *
    * @return a {@link com.google.cloud.bigtable.grpc.BigtableDataClient} object.
    */
+  @Deprecated
   public BigtableDataClient getDataClient() {
     return dataClient;
   }
@@ -378,9 +381,12 @@ public class BigtableSession implements Closeable {
   /**
    * <p>createBulkMutation.</p>
    *
+   * @deprecated Please use {@link #createBulkMutationWrapper(BigtableTableName)}.
+   *
    * @param tableName a {@link com.google.cloud.bigtable.grpc.BigtableTableName} object.
    * @return a {@link com.google.cloud.bigtable.grpc.async.BulkMutation} object.
    */
+  @Deprecated
   public BulkMutation createBulkMutation(BigtableTableName tableName) {
     return new BulkMutation(
         tableName,

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/IntegrationBigtableSessionTest.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/IntegrationBigtableSessionTest.java
@@ -44,9 +44,7 @@ public class IntegrationBigtableSessionTest {
     BigtableOptions options = BigtableOptions.builder().setProjectId(projectId)
         .setInstanceId(instanceId).setUserAgent("Test").build();
     try (BigtableSession bs = new BigtableSession(options)) {
-      ListTablesRequest request = ListTablesRequest.newBuilder()
-          .setParent(options.getInstanceName().getInstanceName()).build();
-      bs.getTableAdminClient().listTables(request);
+      bs.getTableAdminClientWrapper().listTables();
     } catch (Exception e) {
       e.printStackTrace();
     }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestHeaders.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestHeaders.java
@@ -30,6 +30,7 @@ import com.google.cloud.bigtable.config.CredentialOptions;
 import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.data.v2.BigtableDataClient;
 import com.google.cloud.bigtable.data.v2.BigtableDataSettings;
+import com.google.cloud.bigtable.data.v2.models.Query;
 import com.google.common.io.Resources;
 import io.grpc.ForwardingServerCall;
 import io.grpc.ManagedChannelBuilder;
@@ -123,8 +124,8 @@ public class TestHeaders {
 
     xGoogApiPattern = Pattern.compile(".* cbt/.*");
     try (BigtableSession session = new BigtableSession(bigtableOptions)) {
-      session.getDataClient()
-          .readFlatRows(ReadRowsRequest.getDefaultInstance()).next();
+      session.getClientWrapper()
+          .readFlatRows(Query.create("fake-table")).next();
       Assert.assertTrue(serverPasses.get());
     }
   }
@@ -301,4 +302,3 @@ public class TestHeaders {
     }
   }
 }
-


### PR DESCRIPTION
 - Marked BigtableSession#getDataClient & BigtableSession#createBulkMutation as deprecated. 
 - Updated classic client usage to wrappers.