### PR TITLE
Adding BulkMutationGCJClient to translate calls to GCJ's Batcher

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGCJClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableDataGCJClient.java
@@ -28,6 +28,7 @@ import com.google.cloud.bigtable.data.v2.models.Query;
 import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import com.google.cloud.bigtable.data.v2.models.Row;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
+import com.google.cloud.bigtable.grpc.async.BulkMutationGCJClient;
 import com.google.cloud.bigtable.grpc.scanner.FlatRow;
 import com.google.cloud.bigtable.grpc.scanner.FlatRowAdapter;
 import com.google.cloud.bigtable.grpc.scanner.ResultScanner;
@@ -69,7 +70,7 @@ public class BigtableDataGCJClient implements IBigtableDataClient, AutoCloseable
 
   @Override
   public IBulkMutation createBulkMutationBatcher() {
-    throw new UnsupportedOperationException("Not implemented yet");
+    return new BulkMutationGCJClient(delegate.newBulkMutationBatcher());
   }
 
   @Override

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -410,7 +410,7 @@ public class BigtableSession implements Closeable {
    */
   public IBulkMutation createBulkMutationWrapper(BigtableTableName tableName) {
     if (options.useGCJClient()) {
-      return getClientWrapper().createBulkMutationBatcher();
+      return getDataClientWrapper().createBulkMutationBatcher();
     } else {
       return new BulkMutationWrapper(createBulkMutation(tableName), getDataRequestContext());
     }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -409,7 +409,11 @@ public class BigtableSession implements Closeable {
    * @return a {@link IBigtableDataClient} object.
    */
   public IBulkMutation createBulkMutationWrapper(BigtableTableName tableName) {
-    return new BulkMutationWrapper(createBulkMutation(tableName), getDataRequestContext());
+    if (options.useGCJClient()) {
+      return getClientWrapper().createBulkMutationBatcher();
+    } else {
+      return new BulkMutationWrapper(createBulkMutation(tableName), getDataRequestContext());
+    }
   }
 
   /**

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationGCJClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/async/BulkMutationGCJClient.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.grpc.async;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutureCallback;
+import com.google.api.core.ApiFutures;
+import com.google.cloud.bigtable.core.IBulkMutation;
+import com.google.cloud.bigtable.data.v2.models.BulkMutationBatcher;
+import com.google.cloud.bigtable.data.v2.models.RowMutation;
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.MoreExecutors;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * This class is meant to replicate existing {@link BulkMutation} while translating calls to
+ * Google-Cloud-Java's {@link BulkMutationBatcher} api.
+ */
+public class BulkMutationGCJClient implements IBulkMutation {
+
+  // Maximum wait time for all outstanding response futures in either flush() or close() to resolve.
+  private static final long MAX_RPC_WAIT_TIME = 12;
+
+  private final BulkMutationBatcher bulkMutateBatcher;
+  private List<ApiFuture<Void>> responseFutures = new ArrayList<>();
+  private ReentrantLock lock = new ReentrantLock();
+
+  public BulkMutationGCJClient(BulkMutationBatcher bulkMutateBatcher) {
+    this.bulkMutateBatcher = bulkMutateBatcher;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void flush() {
+    lock.lock();
+    try {
+      List<ApiFuture<Void>> accumulatedResFuture = responseFutures;
+      responseFutures = new ArrayList<>();
+      ApiFutures.allAsList(accumulatedResFuture).get(MAX_RPC_WAIT_TIME, TimeUnit.MINUTES);
+    } catch (Exception e) {
+      throw new RuntimeException("Something happened with RPC results", e);
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void sendUnsent() {
+    if (!isFlushed()) {
+      flush();
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public boolean isFlushed() {
+    lock.lock();
+    try {
+      return responseFutures.isEmpty();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public ApiFuture<Void> add(RowMutation rowMutation) {
+    lock.lock();
+    try {
+      final ApiFuture<Void> res = bulkMutateBatcher.add(rowMutation);
+      responseFutures.add(res);
+      ApiFutures.addCallback(res, new ApiFutureCallback<Void>() {
+        @Override
+        public void onFailure(Throwable t) {
+          responseFutures.remove(res);
+        }
+
+        @Override
+        public void onSuccess(Void result) {
+          responseFutures.remove(res);
+        }
+      }, MoreExecutors.directExecutor());
+      return res;
+    } finally {
+      lock.unlock();
+    }
+  }
+}

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableDataGCJClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableDataGCJClient.java
@@ -42,11 +42,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
 import static com.google.api.core.ApiFutures.immediateFuture;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableDataGCJClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestBigtableDataGCJClient.java
@@ -22,6 +22,7 @@ import com.google.api.gax.rpc.ServerStream;
 import com.google.api.gax.rpc.ServerStreamingCallable;
 import com.google.api.gax.rpc.UnaryCallable;
 import com.google.cloud.bigtable.data.v2.BigtableDataClient;
+import com.google.cloud.bigtable.data.v2.models.BulkMutationBatcher;
 import com.google.cloud.bigtable.data.v2.models.ConditionalRowMutation;
 import com.google.cloud.bigtable.data.v2.models.KeyOffset;
 import com.google.cloud.bigtable.data.v2.models.Mutation;
@@ -273,5 +274,14 @@ public class TestBigtableDataGCJClient {
     }
     // BigtableDataGCJClient#close should be invoked
     verify(dataClientV2).close();
+  }
+
+  @Test
+  public void testCreateBulkMutationBatcher(){
+    UnaryCallable<RowMutation, Void> unaryCallable = mock(UnaryCallable.class);
+    BulkMutationBatcher batcher = new BulkMutationBatcher(unaryCallable);
+    when(dataClientV2.newBulkMutationBatcher()).thenReturn(batcher);
+    dataGCJClient.createBulkMutationBatcher();
+    verify(dataClientV2).newBulkMutationBatcher();
   }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationGCJClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationGCJClient.java
@@ -70,14 +70,12 @@ public class TestBulkMutationGCJClient {
 
   @Test(expected = ExecutionException.class)
   public void testAddFailure() throws Exception {
-    String message = "can not perform mutation";
     when(callable.futureCall(rowMutation)).thenReturn(future);
-    future.setException(new RuntimeException(message));
+    future.setException(new RuntimeException("can not perform mutation"));
     ApiFuture<Void> result = bulkMutationClient.add(rowMutation);
     assertTrue(result.isDone());
-    result.get();
-    expect.expectMessage(message);
     verify(callable).futureCall(rowMutation);
+    result.get();
   }
 
   @Test

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationGCJClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationGCJClient.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2019 Google LLC. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.bigtable.grpc.async;
+
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.api.core.SettableApiFuture;
+import com.google.api.gax.rpc.ApiCallContext;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.cloud.bigtable.core.IBulkMutation;
+import com.google.cloud.bigtable.data.v2.models.BulkMutationBatcher;
+import com.google.cloud.bigtable.data.v2.models.RowMutation;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TestBulkMutationGCJClient {
+
+  @Rule
+  public ExpectedException expect = ExpectedException.none();
+
+  @Mock private UnaryCallable<RowMutation, Void> callable;
+  private BulkMutationGCJClient bulkMutationClient;
+  private SettableApiFuture<Void> future;
+  private RowMutation rowMutation = RowMutation.create("fake-table", "fake-key");
+  private final BulkMutationBatcher batcher = new BulkMutationBatcher(new BatcherUnaryCallable());
+
+  @Before
+  public void setUp() {
+    BulkMutationBatcher bulkMutationBatcher = new BulkMutationBatcher(callable);
+    bulkMutationClient = new BulkMutationGCJClient(bulkMutationBatcher);
+    future = SettableApiFuture.create();
+  }
+
+  @Test
+  public void testAdd() {
+    when(callable.futureCall(rowMutation)).thenReturn(future);
+    ApiFuture<Void> result = bulkMutationClient.add(rowMutation);
+    Assert.assertFalse(result.isDone());
+    future.set(null);
+    Assert.assertTrue(result.isDone());
+    verify(callable).futureCall(rowMutation);
+  }
+
+  @Test(expected = ExecutionException.class)
+  public void testAddFailure() throws Exception{
+    String message = "can not perform mutation";
+    when(callable.futureCall(rowMutation)).thenReturn(future);
+    future.setException(new RuntimeException(message));
+    ApiFuture<Void> result = bulkMutationClient.add(rowMutation);
+    Assert.assertTrue(result.isDone());
+    result.get();
+    expect.expectMessage(message);
+    verify(callable).futureCall(rowMutation);
+  }
+
+  @Test
+  public void testCallableTooFewStatuses() {
+    RowMutation rowMutationOther = RowMutation.create("table", "key");
+    SettableApiFuture<Void> futureOther = SettableApiFuture.create();
+    when(callable.futureCall(rowMutation)).thenReturn(future);
+    when(callable.futureCall(rowMutationOther)).thenReturn(futureOther);
+
+    ApiFuture<Void> result = bulkMutationClient.add(rowMutation);
+    ApiFuture<Void> resultOther = bulkMutationClient.add(rowMutationOther);
+    // Only resolving one response
+    future.set(null);
+
+    Assert.assertTrue(result.isDone());
+    Assert.assertFalse(resultOther.isDone());
+
+    Assert.assertFalse(bulkMutationClient.isFlushed());
+    futureOther.set(null);
+    Assert.assertTrue(bulkMutationClient.isFlushed());
+
+    verify(callable).futureCall(rowMutation);
+    verify(callable).futureCall(rowMutationOther);
+  }
+
+  @Test
+  public void testConcurrentBatches() throws Exception {
+    final List<ApiFuture<Void>> futures =
+        Collections.synchronizedList(new ArrayList<ApiFuture<Void>>());
+    final int batchCount = 10;
+    final int concurrentBulkMutationCount = 50;
+
+    Runnable r = new Runnable() {
+      @Override
+      public void run() {
+        IBulkMutation bulkMutation = new BulkMutationGCJClient(batcher);
+        for (int i = 0; i < batchCount * 10; i++) {
+          futures.add(bulkMutation.add(RowMutation.create("fake-table", "fake-key")));
+        }
+        bulkMutation.sendUnsent();
+      }
+    };
+    ExecutorService pool = Executors.newFixedThreadPool(100);
+    for (int i = 0; i < concurrentBulkMutationCount; i++) {
+      pool.execute(r);
+    }
+    pool.shutdown();
+    pool.awaitTermination(100, TimeUnit.SECONDS);
+
+    for (ApiFuture<Void> future : futures) {
+      Assert.assertTrue(future.isDone());
+    }
+    pool.shutdownNow();
+  }
+
+  class BatcherUnaryCallable extends UnaryCallable<RowMutation, Void> {
+    @Override
+    public ApiFuture<Void> futureCall(RowMutation rowMutation, ApiCallContext apiCallContext) {
+      return ApiFutures.immediateFuture(null);
+    }
+  }
+
+  @Test
+  public void testIsFlush() {
+    when(callable.futureCall(rowMutation)).thenReturn(future);
+    bulkMutationClient.add(rowMutation);
+    Assert.assertFalse("BulkMutation should have one pending element",
+        bulkMutationClient.isFlushed());
+    future.set(null);
+    Assert.assertTrue("BulkMutation should not have any pending element",
+        bulkMutationClient.isFlushed());
+    verify(callable).futureCall(rowMutation);
+  }
+
+  @Test
+  public void testFlush() {
+    final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+    final SettableApiFuture<Void> future2 = SettableApiFuture.create();
+    when(callable.futureCall(rowMutation)).thenReturn(future).thenReturn(future2);
+    ApiFuture<Void> result1 = bulkMutationClient.add(rowMutation);
+    ApiFuture<Void> result2 = bulkMutationClient.add(rowMutation);
+
+    Assert.assertFalse(result1.isDone());
+    Assert.assertFalse(result2.isDone());
+    scheduler.schedule(new Runnable() {
+      @Override
+      public void run() {
+        future.set(null);
+        future2.set(null);
+      }
+    }, 50, TimeUnit.MILLISECONDS);
+
+    bulkMutationClient.sendUnsent();
+    Assert.assertTrue(result1.isDone());
+    Assert.assertTrue(result2.isDone());
+
+    verify(callable, times(2)).futureCall(rowMutation);
+  }
+}

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationGCJClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationGCJClient.java
@@ -15,23 +15,21 @@
  */
 package com.google.cloud.bigtable.grpc.async;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import com.google.api.core.ApiFuture;
-import com.google.api.core.ApiFutures;
 import com.google.api.core.SettableApiFuture;
-import com.google.api.gax.rpc.ApiCallContext;
 import com.google.api.gax.rpc.UnaryCallable;
-import com.google.cloud.bigtable.core.IBulkMutation;
 import com.google.cloud.bigtable.data.v2.models.BulkMutationBatcher;
 import com.google.cloud.bigtable.data.v2.models.RowMutation;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -40,21 +38,18 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 @RunWith(MockitoJUnitRunner.class)
 public class TestBulkMutationGCJClient {
 
   @Rule
   public ExpectedException expect = ExpectedException.none();
 
-  @Mock private UnaryCallable<RowMutation, Void> callable;
+  @Mock
+  private UnaryCallable<RowMutation, Void> callable;
+
   private BulkMutationGCJClient bulkMutationClient;
   private SettableApiFuture<Void> future;
   private RowMutation rowMutation = RowMutation.create("fake-table", "fake-key");
-  private final BulkMutationBatcher batcher = new BulkMutationBatcher(new BatcherUnaryCallable());
 
   @Before
   public void setUp() {
@@ -67,118 +62,60 @@ public class TestBulkMutationGCJClient {
   public void testAdd() {
     when(callable.futureCall(rowMutation)).thenReturn(future);
     ApiFuture<Void> result = bulkMutationClient.add(rowMutation);
-    Assert.assertFalse(result.isDone());
+    assertFalse(result.isDone());
     future.set(null);
-    Assert.assertTrue(result.isDone());
+    assertTrue(result.isDone());
     verify(callable).futureCall(rowMutation);
   }
 
   @Test(expected = ExecutionException.class)
-  public void testAddFailure() throws Exception{
+  public void testAddFailure() throws Exception {
     String message = "can not perform mutation";
     when(callable.futureCall(rowMutation)).thenReturn(future);
     future.setException(new RuntimeException(message));
     ApiFuture<Void> result = bulkMutationClient.add(rowMutation);
-    Assert.assertTrue(result.isDone());
+    assertTrue(result.isDone());
     result.get();
     expect.expectMessage(message);
     verify(callable).futureCall(rowMutation);
   }
 
   @Test
-  public void testCallableTooFewStatuses() {
-    RowMutation rowMutationOther = RowMutation.create("table", "key");
-    SettableApiFuture<Void> futureOther = SettableApiFuture.create();
-    when(callable.futureCall(rowMutation)).thenReturn(future);
-    when(callable.futureCall(rowMutationOther)).thenReturn(futureOther);
-
-    ApiFuture<Void> result = bulkMutationClient.add(rowMutation);
-    ApiFuture<Void> resultOther = bulkMutationClient.add(rowMutationOther);
-    // Only resolving one response
-    future.set(null);
-
-    Assert.assertTrue(result.isDone());
-    Assert.assertFalse(resultOther.isDone());
-
-    Assert.assertFalse(bulkMutationClient.isFlushed());
-    futureOther.set(null);
-    Assert.assertTrue(bulkMutationClient.isFlushed());
-
-    verify(callable).futureCall(rowMutation);
-    verify(callable).futureCall(rowMutationOther);
-  }
-
-  @Test
-  public void testConcurrentBatches() throws Exception {
-    final List<ApiFuture<Void>> futures =
-        Collections.synchronizedList(new ArrayList<ApiFuture<Void>>());
-    final int batchCount = 10;
-    final int concurrentBulkMutationCount = 50;
-
-    Runnable r = new Runnable() {
-      @Override
-      public void run() {
-        IBulkMutation bulkMutation = new BulkMutationGCJClient(batcher);
-        for (int i = 0; i < batchCount * 10; i++) {
-          futures.add(bulkMutation.add(RowMutation.create("fake-table", "fake-key")));
-        }
-        bulkMutation.sendUnsent();
-      }
-    };
-    ExecutorService pool = Executors.newFixedThreadPool(100);
-    for (int i = 0; i < concurrentBulkMutationCount; i++) {
-      pool.execute(r);
-    }
-    pool.shutdown();
-    pool.awaitTermination(100, TimeUnit.SECONDS);
-
-    for (ApiFuture<Void> future : futures) {
-      Assert.assertTrue(future.isDone());
-    }
-    pool.shutdownNow();
-  }
-
-  class BatcherUnaryCallable extends UnaryCallable<RowMutation, Void> {
-    @Override
-    public ApiFuture<Void> futureCall(RowMutation rowMutation, ApiCallContext apiCallContext) {
-      return ApiFutures.immediateFuture(null);
-    }
-  }
-
-  @Test
-  public void testIsFlush() {
-    when(callable.futureCall(rowMutation)).thenReturn(future);
-    bulkMutationClient.add(rowMutation);
-    Assert.assertFalse("BulkMutation should have one pending element",
-        bulkMutationClient.isFlushed());
-    future.set(null);
-    Assert.assertTrue("BulkMutation should not have any pending element",
-        bulkMutationClient.isFlushed());
-    verify(callable).futureCall(rowMutation);
-  }
-
-  @Test
-  public void testFlush() {
-    final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+  public void testFlush() throws Exception {
     final SettableApiFuture<Void> future2 = SettableApiFuture.create();
     when(callable.futureCall(rowMutation)).thenReturn(future).thenReturn(future2);
     ApiFuture<Void> result1 = bulkMutationClient.add(rowMutation);
     ApiFuture<Void> result2 = bulkMutationClient.add(rowMutation);
 
-    Assert.assertFalse(result1.isDone());
-    Assert.assertFalse(result2.isDone());
-    scheduler.schedule(new Runnable() {
-      @Override
-      public void run() {
-        future.set(null);
-        future2.set(null);
-      }
-    }, 50, TimeUnit.MILLISECONDS);
+    ScheduledExecutorService executor = Executors.newScheduledThreadPool(1);
+    try {
+      executor.schedule(new Runnable() {
+        @Override
+        public void run() {
+          future.set(null);
+          future2.set(null);
+        }
+      }, 50, TimeUnit.MILLISECONDS);
 
-    bulkMutationClient.flush();
-    Assert.assertTrue(result1.isDone());
-    Assert.assertTrue(result2.isDone());
+      // flush should block until the responses are resolved.
+      bulkMutationClient.flush();
 
+      assertTrue(result1.isDone());
+      assertTrue(result2.isDone());
+    } finally {
+      executor.shutdown();
+      executor.awaitTermination(100, TimeUnit.MILLISECONDS);
+    }
     verify(callable, times(2)).futureCall(rowMutation);
+  }
+
+  @Test
+  public void testIsFlushed() {
+    when(callable.futureCall(rowMutation)).thenReturn(future);
+    bulkMutationClient.add(rowMutation);
+    assertFalse("BulkMutation should have one pending element", bulkMutationClient.isFlushed());
+    future.set(null);
+    assertTrue("BulkMutation should not have any pending element", bulkMutationClient.isFlushed());
+    verify(callable).futureCall(rowMutation);
   }
 }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationGCJClient.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/async/TestBulkMutationGCJClient.java
@@ -175,7 +175,7 @@ public class TestBulkMutationGCJClient {
       }
     }, 50, TimeUnit.MILLISECONDS);
 
-    bulkMutationClient.sendUnsent();
+    bulkMutationClient.flush();
     Assert.assertTrue(result1.isDone());
     Assert.assertTrue(result2.isDone());
 


### PR DESCRIPTION
Initial Implementation of BulkMutationGCJClient
 - Have added MAX_RPC_WAIT_TIME to 12 mins for IBulkMutation#flush. 
 - Maintaining unresolved response futures instead of their count (to be able to flush).
 - Have not implemented AutoCloseable for this, As existing BulkMutation doesn't provide the close.