### PR TITLE
Refactored getter of IBigtableDataClient to getDataClientWrapper 

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -268,7 +268,6 @@ public class BigtableSession implements Closeable {
           com.google.cloud.bigtable.data.v2.BigtableDataClient.create(dataSettings));
 
       // Defer the creation of both the tableAdminClient until we need them.
-      //TODO(rahulkql): Need to identify which resources to initialized for GCJ's adapter case.
       this.adminSettings = BigtableVeneerSettingsFactory.createTableAdminSettings(options);
       this.baseAdminSettings = BaseBigtableTableAdminSettings.create(adminSettings.getStubSettings());
 
@@ -367,7 +366,7 @@ public class BigtableSession implements Closeable {
 
   /**
    * @return a {@link RequestContext} object for use with {@link #getDataClient()} during the
-   * transition to {@link #getClientWrapper()}.
+   * transition to {@link #getDataClientWrapper()}.
    */
   private RequestContext getDataRequestContext() {
     return dataRequestContext;
@@ -378,7 +377,7 @@ public class BigtableSession implements Closeable {
    *
    * @return a {@link IBigtableDataClient} object.
    */
-  public IBigtableDataClient getClientWrapper() {
+  public IBigtableDataClient getDataClientWrapper() {
     if (options.useGCJClient()) {
       return dataGCJClient;
     } else {
@@ -420,7 +419,7 @@ public class BigtableSession implements Closeable {
    * @return a {@link com.google.cloud.bigtable.grpc.async.BulkRead} object.
    */
   public BulkRead createBulkRead(BigtableTableName tableName) {
-    return new BulkRead(getClientWrapper(), tableName,
+    return new BulkRead(getDataClientWrapper(), tableName,
         options.getBulkOptions().getBulkMaxRowKeyCount(),
         BigtableSessionSharedThreadPools.getInstance().getBatchThreadPool()
     );
@@ -451,11 +450,9 @@ public class BigtableSession implements Closeable {
    * @return a {@link BigtableTableAdminClientWrapper} object.
    * @throws java.io.IOException if any.
    */
-  //TODO(rahulkql): rename the getter to getTableAdminClient.
   public synchronized IBigtableTableAdminClient getTableAdminClientWrapper() throws IOException {
     if (options.useGCJClient()) {
       if (adminGCJClient == null) {
-        //TODO(rahulkql): Decide If these clients need to be part of #close
         com.google.cloud.bigtable.admin.v2.BigtableTableAdminClient adminClientV2 =
             com.google.cloud.bigtable.admin.v2.BigtableTableAdminClient.create(adminSettings);
         BaseBigtableTableAdminClient baseAdminClientV2 =

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestAppProfile.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestAppProfile.java
@@ -118,22 +118,22 @@ public class TestAppProfile {
 
   @Test
   public void testReadRows() throws Exception {
-    defaultSession.getClientWrapper().readRows(Query.create(TABLE_ID)).next();
+    defaultSession.getDataClientWrapper().readRows(Query.create(TABLE_ID)).next();
     ReadRowsRequest req = fakeDataService.popLastRequest();
     Preconditions.checkState(req.getAppProfileId().isEmpty());
 
-    profileSession.getClientWrapper().readRows(Query.create(TABLE_ID));
+    profileSession.getDataClientWrapper().readRows(Query.create(TABLE_ID));
     ReadRowsRequest req2 = fakeDataService.popLastRequest();
     Assert.assertEquals(req2.getAppProfileId(), "my-app-profile");
   }
 
   @Test
   public void testSampleRowKeys() throws Exception {
-    defaultSession.getClientWrapper().sampleRowKeys(TABLE_ID);
+    defaultSession.getDataClientWrapper().sampleRowKeys(TABLE_ID);
     SampleRowKeysRequest req = fakeDataService.popLastRequest();
     Preconditions.checkState(req.getAppProfileId().isEmpty());
 
-    profileSession.getClientWrapper().sampleRowKeys(TABLE_ID);
+    profileSession.getDataClientWrapper().sampleRowKeys(TABLE_ID);
     SampleRowKeysRequest req2 = fakeDataService.popLastRequest();
     Assert.assertEquals(req2.getAppProfileId(), "my-app-profile");
   }
@@ -141,11 +141,11 @@ public class TestAppProfile {
   @Test
   public void testMutateRow() throws Exception {
     RowMutation rowMutation = RowMutation.create(TABLE_ID, "fake-key");
-    defaultSession.getClientWrapper().mutateRow(rowMutation);
+    defaultSession.getDataClientWrapper().mutateRow(rowMutation);
     MutateRowRequest req = fakeDataService.popLastRequest();
     Preconditions.checkState(req.getAppProfileId().isEmpty());
 
-    profileSession.getClientWrapper().mutateRow(rowMutation);
+    profileSession.getDataClientWrapper().mutateRow(rowMutation);
     MutateRowRequest req2 = fakeDataService.popLastRequest();
     Assert.assertEquals(req2.getAppProfileId(), "my-app-profile");
 
@@ -168,11 +168,11 @@ public class TestAppProfile {
         ConditionalRowMutation.create(TABLE_ID, "fake-key")
             .then(Mutation.create()
                 .setCell("fakeFamily", "qualifer", "value"));
-    defaultSession.getClientWrapper().checkAndMutateRow(checkAndMuate);
+    defaultSession.getDataClientWrapper().checkAndMutateRow(checkAndMuate);
     CheckAndMutateRowRequest req = fakeDataService.popLastRequest();
     Preconditions.checkState(req.getAppProfileId().isEmpty());
 
-    profileSession.getClientWrapper().checkAndMutateRow(checkAndMuate);
+    profileSession.getDataClientWrapper().checkAndMutateRow(checkAndMuate);
     CheckAndMutateRowRequest req2 = fakeDataService.popLastRequest();
     Assert.assertEquals(req2.getAppProfileId(), "my-app-profile");
   }
@@ -180,11 +180,11 @@ public class TestAppProfile {
   @Test
   public void testReadModifyWrite() throws Exception {
     ReadModifyWriteRow readModifyRow = ReadModifyWriteRow.create(TABLE_ID, "fake-key");
-    defaultSession.getClientWrapper().readModifyWriteRow(readModifyRow);
+    defaultSession.getDataClientWrapper().readModifyWriteRow(readModifyRow);
     ReadModifyWriteRowRequest req = fakeDataService.popLastRequest();
     Preconditions.checkState(req.getAppProfileId().isEmpty());
 
-    profileSession.getClientWrapper().readModifyWriteRow(readModifyRow);
+    profileSession.getDataClientWrapper().readModifyWriteRow(readModifyRow);
     ReadModifyWriteRowRequest req2 = fakeDataService.popLastRequest();
     Assert.assertEquals(req2.getAppProfileId(), "my-app-profile");
   }

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestHeaders.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestHeaders.java
@@ -124,7 +124,7 @@ public class TestHeaders {
 
     xGoogApiPattern = Pattern.compile(".* cbt/.*");
     try (BigtableSession session = new BigtableSession(bigtableOptions)) {
-      session.getClientWrapper()
+      session.getDataClientWrapper()
           .readFlatRows(Query.create("fake-table")).next();
       Assert.assertTrue(serverPasses.get());
     }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
@@ -126,7 +126,7 @@ public abstract class AbstractBigtableTable implements Table {
     this.bigtableConnection = bigtableConnection;
     BigtableSession session = bigtableConnection.getSession();
     this.options = session.getOptions();
-    this.clientWrapper = session.getClientWrapper();
+    this.clientWrapper = session.getDataClientWrapper();
     this.hbaseAdapter = hbaseAdapter;
     this.tableName = hbaseAdapter.getTableName();
   }

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutatorHelper.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableBufferedMutatorHelper.java
@@ -88,7 +88,7 @@ public class BigtableBufferedMutatorHelper {
     this.options = session.getOptions();
     BigtableTableName tableName = this.adapter.getBigtableTableName();
     this.bulkMutation = session.createBulkMutationWrapper(tableName);
-    this.dataClient = session.getClientWrapper();
+    this.dataClient = session.getDataClientWrapper();
     this.operationAccountant = new OperationAccountant();
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
@@ -325,7 +325,6 @@ public class BigtableOptionsFactory {
     }
     bigtableOptionsBuilder.setUseBatch(configuration.getBoolean(BIGTABLE_USE_BATCH, false));
 
-    //TODO(rahulkql): verify presence of this env varible.
     bigtableOptionsBuilder.setUseGCJClient(configuration.getBoolean(BIGTABLE_USE_GCJ_CLIENT,
         false));
     return bigtableOptionsBuilder.build();

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/org/apache/hadoop/hbase/client/AbstractBigtableConnection.java
@@ -225,7 +225,7 @@ public abstract class AbstractBigtableConnection implements Connection, CommonCo
     RegionLocator locator = getCachedLocator(tableName);
 
     if (locator == null) {
-      locator = new BigtableRegionLocator(tableName, getOptions(), getSession().getClientWrapper()) {
+      locator = new BigtableRegionLocator(tableName, getOptions(), getSession().getDataClientWrapper()) {
 
         @Override
         public SampledRowKeysAdapter getSampledRowKeysAdapter(TableName tableName,

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBatchExecutor.java
@@ -147,7 +147,7 @@ public class TestBatchExecutor {
 
     MockitoAnnotations.initMocks(this);
     when(mockBulkMutation.add(any(RowMutation.class))).thenReturn(mockFuture);
-    when(mockBigtableSession.getClientWrapper()).thenReturn(mockDataClient);
+    when(mockBigtableSession.getDataClientWrapper()).thenReturn(mockDataClient);
     when(mockDataClient.readModifyWriteRowAsync(any(ReadModifyWriteRow.class))).thenReturn(mockFuture);
     when(mockBigtableSession.createBulkMutationWrapper(any(BigtableTableName.class))).thenReturn(mockBulkMutation);
     when(mockBigtableSession.createBulkRead(any(BigtableTableName.class))).thenReturn(mockBulkRead);

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableBufferedMutator.java
@@ -31,7 +31,6 @@ import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import com.google.cloud.bigtable.data.v2.internal.RequestContext;
 import com.google.cloud.bigtable.data.v2.models.ReadModifyWriteRow;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.TableName;
@@ -86,7 +85,7 @@ public class TestBigtableBufferedMutator {
   public void setUp() {
     MockitoAnnotations.initMocks(this);
     when(mockSession.createBulkMutationWrapper(any(BigtableTableName.class))).thenReturn(mockBulkMutation);
-    when(mockSession.getClientWrapper()).thenReturn(mockDataClient);
+    when(mockSession.getDataClientWrapper()).thenReturn(mockDataClient);
   }
 
   @After

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableTable.java
@@ -113,7 +113,7 @@ public class TestBigtableTable {
     when(mockConnection.getConfiguration()).thenReturn(config);
     when(mockConnection.getSession()).thenReturn(mockSession);
     when(mockSession.getOptions()).thenReturn(options);
-    when(mockSession.getClientWrapper()).thenReturn(mockBigtableDataClient);
+    when(mockSession.getDataClientWrapper()).thenReturn(mockBigtableDataClient);
     when(mockBigtableDataClient.readFlatRows(isA(Query.class))).thenReturn(mockResultScanner);
     table = new AbstractBigtableTable(mockConnection, hbaseAdapter){};
   }

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/batch/common/CloudBigtableServiceImpl.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/batch/common/CloudBigtableServiceImpl.java
@@ -28,7 +28,7 @@ public class CloudBigtableServiceImpl implements CloudBigtableService {
   public List<KeyOffset> getSampleRowKeys(CloudBigtableTableConfiguration config)
       throws IOException {
     try (BigtableSession session = new BigtableSession(config.toBigtableOptions())) {
-      return session.getClientWrapper().sampleRowKeys(config.getTableId());
+      return session.getDataClientWrapper().sampleRowKeys(config.getTableId());
     }
   }
 }

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableIO.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableIO.java
@@ -621,7 +621,8 @@ public class CloudBigtableIO {
 
       // This will use cached data channels under the covers.
       session = new BigtableSession(BigtableOptionsFactory.fromConfiguration(config));
-      scanner = session.getClientWrapper().readFlatRows(Query.fromProto(source.getConfiguration().getRequest()));
+      scanner = session.getDataClientWrapper()
+              .readFlatRows(Query.fromProto(source.getConfiguration().getRequest()));
     }
 
     /**

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTable.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTable.java
@@ -86,7 +86,7 @@ public class BigtableAsyncTable implements AsyncTable<ScanResultConsumer> {
 
   public BigtableAsyncTable(CommonConnection connection, HBaseRequestAdapter hbaseAdapter) {
     this.connection = connection;
-    this.clientWrapper = connection.getSession().getClientWrapper();
+    this.clientWrapper = connection.getSession().getDataClientWrapper();
     this.hbaseAdapter = hbaseAdapter;
     this.tableName = hbaseAdapter.getTableName();
   }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.security.User;
 
 import com.google.bigtable.v2.SampleRowKeysRequest;
-import com.google.bigtable.v2.SampleRowKeysResponse;
 import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.config.Logger;
 import com.google.cloud.bigtable.grpc.BigtableSession;
@@ -279,7 +278,7 @@ public class BigtableAsyncConnection implements AsyncConnection, CommonConnectio
 
   @Override
   public AsyncTableRegionLocator getRegionLocator(TableName tableName) {
-    return new BigtableAsyncTableRegionLocator(tableName, options, this.session.getClientWrapper());
+    return new BigtableAsyncTableRegionLocator(tableName, options, this.session.getDataClientWrapper());
   }
 
   @Override
@@ -338,7 +337,7 @@ public class BigtableAsyncConnection implements AsyncConnection, CommonConnectio
     ServerName serverName = ServerName.valueOf(options.getDataHost(), options.getPort(), 0);
     SampleRowKeysRequest.Builder request = SampleRowKeysRequest.newBuilder();
     request.setTableName(options.getInstanceName().toTableNameStr(tableName.getNameAsString()));
-    List<KeyOffset> sampleRowKeyResponse = this.session.getClientWrapper().sampleRowKeys(tableName.getNameAsString());
+    List<KeyOffset> sampleRowKeyResponse = this.session.getDataClientWrapper().sampleRowKeys(tableName.getNameAsString());
 
     return getSampledRowKeysAdapter(tableName, serverName).adaptResponse(sampleRowKeyResponse)
         .stream()

--- a/bigtable-test/bigtable-emulator-maven-plugin/src/it/simple-it/src/test/java/SimpleIT.java
+++ b/bigtable-test/bigtable-emulator-maven-plugin/src/it/simple-it/src/test/java/SimpleIT.java
@@ -50,7 +50,7 @@ public class SimpleIT {
       IBigtableTableAdminClient tableAdminClient = session.getTableAdminClientWrapper();
       tableAdminClient.createTable(CreateTableRequest.of(tableId).addFamily(family));
 
-      IBigtableDataClient dataClient = session.getClientWrapper();
+      IBigtableDataClient dataClient = session.getDataClientWrapper();
       dataClient.mutateRow(RowMutation.create(tableId, key).setCell(family, "", value));
       List<Row> results = dataClient.readRowsAsync(Query.create(tableId).rowKey(key)).get();
 


### PR DESCRIPTION
- Updated getClientWrapper to getDataClientWrapper.
- Removed TODO(rahulkql) from `BigtableOptionsFactory` & `BigtableSession`.

Note: Refactor was done under the assumption that user would not be affected from this.