### PR TITLE
Added check for `watchdog` in `BigtableSession#close`

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -640,7 +640,9 @@ public class BigtableSession implements Closeable {
   /** {@inheritDoc} */
   @Override
   public synchronized void close() throws IOException {
-    watchdog.stop();
+    if (watchdog != null) {
+      watchdog.stop();
+    }
 
     long timeoutNanos = TimeUnit.SECONDS.toNanos(10);
     long endTimeNanos = System.nanoTime() + timeoutNanos;


### PR DESCRIPTION
Added a check for `watchdog` in `BigtableSession#close`, As watchdog would not be instantiated in case of GCJAdapters.