### PR TITLE
Added `RandomStringUtils` Test with prevetted tableName

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestCreateTable.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestCreateTable.java
@@ -21,6 +21,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.commons.lang.RandomStringUtils;
 import org.apache.hadoop.hbase.HRegionLocation;
 import org.apache.hadoop.hbase.TableExistsException;
 import org.apache.hadoop.hbase.TableName;
@@ -66,33 +67,27 @@ public abstract class AbstractTestCreateTable extends AbstractTest {
     if (!"true".equals(shouldTest) || testTableNames_Counter.incrementAndGet() > 1) {
       return;
     }
+    String[] badNames =
+        { "-x", ".x", "a!", "a@", "a#", "a$", "a%", "a^", "a&", "a*", "a(", "a+", "a=", "a~", "a`",
+            "a{", "a[", "a|", "a\\", "a/", "a<", "a,", "a?" };
+    for (String badName : badNames) {
+      assertBadTableName(badName);
+    }
+
+    for (int i = 0; i < 20; i++) {
+      String randomString = RandomStringUtils.random(10, false, false);
+      if (isBadTableName(randomString)) {
+        assertBadTableName("a" + randomString);
+      }
+    }
+
     // more than one subclass can run at the same time.  Ensure that this method is serial.
     String[] goodNames = { "a", "1", "_", // Really?  Yuck.
         "_x", "a-._5x", "_a-._5x",
         // TODO(sduskis): Join the last 2 strings once the Bigtable backend supports table names
         // longer than 50 characters.
         "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi", "jklmnopqrstuvwxyz1234567890_-." };
-    String[] badNames =
-        { "-x", ".x", "a!", "a@", "a#", "a$", "a%", "a^", "a&", "a*", "a(", "a+", "a=", "a~", "a`",
-            "a{", "a[", "a|", "a\\", "a/", "a<", "a,", "a?",
-            // TODO(issue #1785): this always fails in Cloud Bigtable, but fails intermittently in
-            // HBase.  We need to find the difference, document it, and create a better test.
-            //            "a" + RandomStringUtils.random(10, false, false)
-        };
-
-    for (String badName : badNames) {
-      boolean failed = false;
-      try {
-        createTable(TableName.valueOf(badName));
-      } catch (Exception ex) {
-        //TODO verify - added RuntimeException check as RandomStringUtils seems to be generating a string server side doesn't like
-        failed = true;
-      }
-      Assert.assertTrue("Should fail as table name: '" + badName + "'", failed);
-    }
-
     final TableName[] tableNames = getConnection().getAdmin().listTableNames();
-
     List<ListenableFuture<Void>> futures = new ArrayList<>();
     ListeningExecutorService es = MoreExecutors.listeningDecorator(sharedTestEnv.getExecutor());
     for (final String goodName : goodNames) {
@@ -129,6 +124,27 @@ public abstract class AbstractTestCreateTable extends AbstractTest {
   private boolean contains(TableName[] tableNames, TableName tableNameTocheck) {
     for (TableName tableName : tableNames) {
       if (tableName.equals(tableNameTocheck)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void assertBadTableName(String tableName){
+    boolean failed = false;
+    try {
+      createTable(TableName.valueOf(tableName));
+    } catch (Exception ex) {
+      //TODO verify - added RuntimeException check as RandomStringUtils seems to be generating a string server side doesn't like
+      failed = true;
+    }
+    Assert.assertTrue("Should fail as table name: '" + tableName + "'", failed);
+  }
+
+  private static boolean isBadTableName(String tableName) {
+    byte[] tableChars = tableName.getBytes();
+    for(byte codePoint : tableChars){
+      if (!Character.isAlphabetic(codePoint)) {
         return true;
       }
     }

--- a/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestCreateTable.java
+++ b/bigtable-client-core-parent/bigtable-hbase-integration-tests-common/src/test/java/com/google/cloud/bigtable/hbase/AbstractTestCreateTable.java
@@ -131,14 +131,12 @@ public abstract class AbstractTestCreateTable extends AbstractTest {
   }
 
   private void assertBadTableName(String tableName){
-    boolean failed = false;
     try {
       createTable(TableName.valueOf(tableName));
+      Assert.fail("Should fail as table name: '" + tableName + "'");
     } catch (Exception ex) {
       //TODO verify - added RuntimeException check as RandomStringUtils seems to be generating a string server side doesn't like
-      failed = true;
     }
-    Assert.assertTrue("Should fail as table name: '" + tableName + "'", failed);
   }
 
   private static boolean isBadTableName(String tableName) {


### PR DESCRIPTION
Fixes #1785 

The reason for test failure for `RandomStringUtils#random` was the difference in checks present for the table name. Please see [here](https://github.com/apache/hbase/blob/branch-1.4/hbase-common/src/main/java/org/apache/hadoop/hbase/TableName.java#L189-L195) for Hbase1 TableName and [here](https://github.com/apache/hbase/blob/rel/2.1.4/hbase-common/src/main/java/org/apache/hadoop/hbase/TableName.java#L206-L211) for Hbase2 TableName.

- `Hbase1`  expects character from the alphabetic character between `[a-zA-Z0-9.]`. It doesn't support any other characters, This is similar in the case of Cloud Bigtable as well.

- `Hbase2` seems to accept multi-lingual alphabetic character even of different language. For example`"a웷忀꺡힟"` works in **Hbase2** but not with **CloudBigtable**.