### PR TITLE
Support for skipping the emulator maven plugin

### DIFF
--- a/bigtable-test/bigtable-emulator-maven-plugin/README.md
+++ b/bigtable-test/bigtable-emulator-maven-plugin/README.md
@@ -65,3 +65,5 @@ Usage:
   ```java
       Connection connection = BigtableConfiguration.connect("fakeproject", "fakeinstace");
    ```
+- If `maven.test.skip` is set to true the emulator will not start. The emulator can also be controlled directly 
+  by setting the boolean property `bigtable.emulator.skip`.

--- a/bigtable-test/bigtable-emulator-maven-plugin/src/main/java/com/google/cloud/bigtable/test/emulator/Start.java
+++ b/bigtable-test/bigtable-emulator-maven-plugin/src/main/java/com/google/cloud/bigtable/test/emulator/Start.java
@@ -40,8 +40,15 @@ public class Start extends AbstractMojo {
   @Parameter(readonly = true, defaultValue = "bigtable.emulator.endpoint")
   private String propertyName;
 
+  @Parameter(defaultValue = "${maven.test.skip}", property = "bigtable.emulator.skip")
+  private boolean skip;
+
 
   public void execute() throws MojoExecutionException {
+    if(skip) {
+      getLog().info("bigtable.emulator.skip resolved to true. Skipping excution.");
+      return;
+    }
     if (emulatorPath == null) {
       GcloudHelper helper = new GcloudHelper(Executors.newCachedThreadPool());
       emulatorPath = helper.getEmulatorPath();

--- a/bigtable-test/bigtable-emulator-maven-plugin/src/main/java/com/google/cloud/bigtable/test/emulator/Stop.java
+++ b/bigtable-test/bigtable-emulator-maven-plugin/src/main/java/com/google/cloud/bigtable/test/emulator/Stop.java
@@ -29,7 +29,11 @@ public class Stop extends AbstractMojo {
   public void execute() throws MojoExecutionException, MojoFailureException {
     EmulatorController controller = (EmulatorController) getPluginContext().get(EmulatorController.class);
 
-    if(controller.isStarted())
+    if(controllerIsRunning(controller))
       controller.stop();
+  }
+
+  private boolean controllerIsRunning(EmulatorController controller) {
+    return controller != null && controller.isStarted();
   }
 }


### PR DESCRIPTION
We need to skip execution in some of the jobs in our delivery pipeline.