### PR TITLE
Expose setters with ValueProvider as public

### DIFF
--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableScanConfiguration.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableScanConfiguration.java
@@ -112,7 +112,7 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
      * @param request The {@link ReadRowsRequest} to add to the configuration.
      * @return The {@link CloudBigtableScanConfiguration.Builder} for chaining convenience.
      */
-    Builder withRequest(ValueProvider<ReadRowsRequest> request) {
+    public Builder withRequest(ValueProvider<ReadRowsRequest> request) {
       this.request = request;
       return this;
     }
@@ -157,7 +157,7 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
      * returns {@link CloudBigtableScanConfiguration.Builder}.
      */
     @Override
-    Builder withProjectId(ValueProvider<String> projectId) {
+    public Builder withProjectId(ValueProvider<String> projectId) {
       super.withProjectId(projectId);
       return this;
     }
@@ -175,7 +175,7 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
      * {@inheritDoc}
      */
     @Override
-    Builder withInstanceId(ValueProvider<String> instanceId) {
+    public Builder withInstanceId(ValueProvider<String> instanceId) {
       super.withInstanceId(instanceId);
       return this;
     }
@@ -193,7 +193,7 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
      * {@inheritDoc}
      */
     @Override
-    Builder withAppProfileId(ValueProvider<String> appProfileId) {
+    public Builder withAppProfileId(ValueProvider<String> appProfileId) {
       super.withAppProfileId(appProfileId);
       return this;
     }
@@ -211,7 +211,7 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
      * {@inheritDoc}
      */
     @Override
-    Builder withConfiguration(String key, ValueProvider<String> value) {
+    public Builder withConfiguration(String key, ValueProvider<String> value) {
       super.withConfiguration(key, value);
       return this;
     }
@@ -233,7 +233,7 @@ public class CloudBigtableScanConfiguration extends CloudBigtableTableConfigurat
      * so that it returns {@link CloudBigtableScanConfiguration.Builder}.
      */
     @Override
-    Builder withTableId(ValueProvider<String> tableId) {
+    public Builder withTableId(ValueProvider<String> tableId) {
       super.withTableId(tableId);
       return this;
     }

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableTableConfiguration.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableTableConfiguration.java
@@ -52,7 +52,7 @@ public class CloudBigtableTableConfiguration extends CloudBigtableConfiguration 
      * @param tableId The table to connect to.
      * @return The {@link CloudBigtableTableConfiguration.Builder} for chaining convenience.
      */
-    Builder withTableId(ValueProvider<String> tableId) {
+    public Builder withTableId(ValueProvider<String> tableId) {
       this.tableId = tableId;
       return this;
     }
@@ -76,7 +76,7 @@ public class CloudBigtableTableConfiguration extends CloudBigtableConfiguration 
      * returns {@link CloudBigtableTableConfiguration.Builder}.
      */
     @Override
-    Builder withProjectId(ValueProvider<String> projectId) {
+    public Builder withProjectId(ValueProvider<String> projectId) {
       super.withProjectId(projectId);
       return this;
     }
@@ -100,7 +100,7 @@ public class CloudBigtableTableConfiguration extends CloudBigtableConfiguration 
      * returns {@link CloudBigtableTableConfiguration.Builder}.
      */
     @Override
-    Builder withInstanceId(ValueProvider<String> instanceId) {
+    public Builder withInstanceId(ValueProvider<String> instanceId) {
       super.withInstanceId(instanceId);
       return this;
     }
@@ -124,7 +124,7 @@ public class CloudBigtableTableConfiguration extends CloudBigtableConfiguration 
      * returns {@link CloudBigtableTableConfiguration.Builder}.
      */
     @Override
-    Builder withAppProfileId(ValueProvider<String> appProfileId) {
+    public Builder withAppProfileId(ValueProvider<String> appProfileId) {
       super.withAppProfileId(appProfileId);
       return this;
     }
@@ -148,7 +148,7 @@ public class CloudBigtableTableConfiguration extends CloudBigtableConfiguration 
      * that it returns {@link CloudBigtableTableConfiguration.Builder}.
      */
     @Override
-    Builder withConfiguration(String key, ValueProvider<String> value) {
+    public Builder withConfiguration(String key, ValueProvider<String> value) {
       super.withConfiguration(key, value);
       return this;
     }


### PR DESCRIPTION
Fixes #2155 


With this change a users should be able to set runtime variable directly with `CloudBigtableTableConfiguration` and `CloudBigtableScanConfiguration`.