### PR TITLE
Introduce different timeouts for mutateRows & read rows

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -102,7 +102,7 @@ public class BigtableOptions implements Serializable, Cloneable {
       options.useGCJClient = false;
 
       options.retryOptions = new RetryOptions.Builder().build();
-      options.callOptionsConfig = new CallOptionsConfig.Builder().build();
+      options.callOptionsConfig = CallOptionsConfig.builder().build();
       // CredentialOptions.defaultCredentials() gets credentials from well known locations, such as
       // the Google Compute Engine metadata service or gcloud configuration in other environments. A
       // user can also override the default behavior with P12 or JSON configuration.

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableVeneerSettingsFactory.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableVeneerSettingsFactory.java
@@ -240,7 +240,7 @@ public class BigtableVeneerSettingsFactory {
     Duration totalTimeout =
         ofMillis(
             callOptions.isUseTimeout()
-                ? callOptions.getLongRpcTimeoutMs()
+                ? callOptions.getReadStreamRpcTimeoutMs()
                 : retryOptions.getMaxElapsedBackoffMillis());
 
     retryBuilder

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CallOptionsConfig.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CallOptionsConfig.java
@@ -109,8 +109,8 @@ public class CallOptionsConfig implements Serializable {
      *
      * @param longRpcTimeoutMs timeout value in milliseconds.
      * @return a {@link Builder} object, for chaining
-     *
-     * @deprecated Please use {@link #setMutateRpcTimeoutMs(int)} or {@link #setReadRowsRpcTimeoutMs(int)}.
+     * @deprecated Please use {@link #setMutateRpcTimeoutMs(int)} or {@link
+     *     #setReadRowsRpcTimeoutMs(int)}.
      */
     @Deprecated
     public Builder setLongRpcTimeoutMs(int longRpcTimeoutMs) {
@@ -121,11 +121,13 @@ public class CallOptionsConfig implements Serializable {
 
     /**
      * The amount of milliseconds to wait before issuing a client side timeout for mutation RPCs.
+     *
      * @param mutateRpcTimeoutMs timeout value in milliseconds.
      * @return a {@link Builder} object, for chaining
      */
     public Builder setMutateRpcTimeoutMs(int mutateRpcTimeoutMs) {
-      Preconditions.checkArgument(mutateRpcTimeoutMs > 0, "Long Timeout ms has to be greater than 0");
+      Preconditions.checkArgument(
+          mutateRpcTimeoutMs > 0, "Long Timeout ms has to be greater than 0");
       this.mutateRpcTimeoutMs = mutateRpcTimeoutMs;
       return this;
     }
@@ -133,11 +135,13 @@ public class CallOptionsConfig implements Serializable {
     /**
      * The amount of milliseconds to wait before issuing a client side timeout for readRows
      * streaming RPCs.
+     *
      * @param readStreamRpcTimeoutMs timeout value in milliseconds.
      * @return a {@link Builder} object, for chaining
      */
-    public Builder setReadRowsRpcTimeoutMs(int readStreamRpcTimeoutMs){
-      Preconditions.checkArgument(readStreamRpcTimeoutMs > 0, "Read Stream Timeout ms has to be greater than 0");
+    public Builder setReadRowsRpcTimeoutMs(int readStreamRpcTimeoutMs) {
+      Preconditions.checkArgument(
+          readStreamRpcTimeoutMs > 0, "Read Stream Timeout ms has to be greater than 0");
       this.readRowsRpcTimeoutMs = readStreamRpcTimeoutMs;
       return this;
     }
@@ -159,7 +163,6 @@ public class CallOptionsConfig implements Serializable {
    * @param useTimeout a boolean.
    * @param unaryRpcTimeoutMs an int.
    * @param longRpcTimeoutMs an int.
-   *
    * @deprecated Please use {@link #builder()}
    */
   @Deprecated
@@ -221,8 +224,8 @@ public class CallOptionsConfig implements Serializable {
    * Getter for the field <code>longRpcTimeoutMs</code>.
    *
    * @return an int.
-   *
-   * @deprecated Please use {@link #getMutateRpcTimeoutMs()} or {@link #getReadStreamRpcTimeoutMs()}.
+   * @deprecated Please use {@link #getMutateRpcTimeoutMs()} or {@link
+   *     #getReadStreamRpcTimeoutMs()}.
    */
   @Deprecated
   public int getLongRpcTimeoutMs() {
@@ -230,7 +233,7 @@ public class CallOptionsConfig implements Serializable {
   }
 
   /**
-   * <p>Getter for the field <code>mutateRpcTimeoutMs</code>.</p>
+   * Getter for the field <code>mutateRpcTimeoutMs</code>.
    *
    * @return an int.
    */
@@ -239,7 +242,7 @@ public class CallOptionsConfig implements Serializable {
   }
 
   /**
-   * <p>Getter for the field <code>readStreamRpcTimeoutMs</code>.</p>
+   * Getter for the field <code>readStreamRpcTimeoutMs</code>.
    *
    * @return an int.
    */

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CallOptionsConfig.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CallOptionsConfig.java
@@ -105,7 +105,8 @@ public class CallOptionsConfig implements Serializable {
     }
 
     /**
-     * The amount of milliseconds to wait before issuing a client side timeout for long RPCs.
+     * The amount of milliseconds to wait before issuing a client side timeout for long running
+     * RPCs.
      *
      * @param longRpcTimeoutMs timeout value in milliseconds.
      * @return a {@link Builder} object, for chaining
@@ -114,26 +115,28 @@ public class CallOptionsConfig implements Serializable {
      */
     @Deprecated
     public Builder setLongRpcTimeoutMs(int longRpcTimeoutMs) {
-      Preconditions.checkArgument(longRpcTimeoutMs > 0, "Long Timeout ms has to be greater than 0");
+      Preconditions.checkArgument(
+          longRpcTimeoutMs > 0, "Long running RPC Timeout ms has to be greater than 0");
       this.longRpcTimeoutMs = longRpcTimeoutMs;
       return this;
     }
 
     /**
-     * The amount of milliseconds to wait before issuing a client side timeout for mutation RPCs.
+     * The amount of time in milliseconds to wait before issuing a client side timeout for row
+     * mutation RPCs.
      *
      * @param mutateRpcTimeoutMs timeout value in milliseconds.
      * @return a {@link Builder} object, for chaining
      */
     public Builder setMutateRpcTimeoutMs(int mutateRpcTimeoutMs) {
       Preconditions.checkArgument(
-          mutateRpcTimeoutMs > 0, "Long Timeout ms has to be greater than 0");
+          mutateRpcTimeoutMs > 0, "Mutate Rows RPC Timeout ms has to be greater than 0");
       this.mutateRpcTimeoutMs = mutateRpcTimeoutMs;
       return this;
     }
 
     /**
-     * The amount of milliseconds to wait before issuing a client side timeout for readRows
+     * The amount of time in millisecond to wait before issuing a client side timeout for readRows
      * streaming RPCs.
      *
      * @param readStreamRpcTimeoutMs timeout value in milliseconds.
@@ -141,7 +144,7 @@ public class CallOptionsConfig implements Serializable {
      */
     public Builder setReadRowsRpcTimeoutMs(int readStreamRpcTimeoutMs) {
       Preconditions.checkArgument(
-          readStreamRpcTimeoutMs > 0, "Read Stream Timeout ms has to be greater than 0");
+          readStreamRpcTimeoutMs > 0, "Read Stream RPC Timeout ms has to be greater than 0");
       this.readRowsRpcTimeoutMs = readStreamRpcTimeoutMs;
       return this;
     }

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CallOptionsConfig.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CallOptionsConfig.java
@@ -55,6 +55,8 @@ public class CallOptionsConfig implements Serializable {
     private boolean useTimeout = USE_TIMEOUT_DEFAULT;
     private int shortRpcTimeoutMs = SHORT_TIMEOUT_MS_DEFAULT;
     private int longRpcTimeoutMs = LONG_TIMEOUT_MS_DEFAULT;
+    private int mutateRpcTimeoutMs = LONG_TIMEOUT_MS_DEFAULT;
+    private int readRowsRpcTimeoutMs = LONG_TIMEOUT_MS_DEFAULT;
 
     @Deprecated
     public Builder() {}
@@ -63,6 +65,8 @@ public class CallOptionsConfig implements Serializable {
       this.useTimeout = original.useTimeout;
       this.shortRpcTimeoutMs = original.shortRpcTimeoutMs;
       this.longRpcTimeoutMs = original.longRpcTimeoutMs;
+      this.mutateRpcTimeoutMs = original.mutateRpcTimeoutMs;
+      this.readRowsRpcTimeoutMs = original.readStreamRpcTimeoutMs;
     }
 
     /**
@@ -105,21 +109,49 @@ public class CallOptionsConfig implements Serializable {
      *
      * @param longRpcTimeoutMs timeout value in milliseconds.
      * @return a {@link Builder} object, for chaining
+     *
+     * @deprecated Please use {@link #setMutateRpcTimeoutMs(int)} or {@link #setReadRowsRpcTimeoutMs(int)}.
      */
+    @Deprecated
     public Builder setLongRpcTimeoutMs(int longRpcTimeoutMs) {
       Preconditions.checkArgument(longRpcTimeoutMs > 0, "Long Timeout ms has to be greater than 0");
       this.longRpcTimeoutMs = longRpcTimeoutMs;
       return this;
     }
 
+    /**
+     * The amount of milliseconds to wait before issuing a client side timeout for mutation RPCs.
+     * @param mutateRpcTimeoutMs timeout value in milliseconds.
+     * @return a {@link Builder} object, for chaining
+     */
+    public Builder setMutateRpcTimeoutMs(int mutateRpcTimeoutMs) {
+      Preconditions.checkArgument(mutateRpcTimeoutMs > 0, "Long Timeout ms has to be greater than 0");
+      this.mutateRpcTimeoutMs = mutateRpcTimeoutMs;
+      return this;
+    }
+
+    /**
+     * The amount of milliseconds to wait before issuing a client side timeout for readRows
+     * streaming RPCs.
+     * @param readStreamRpcTimeoutMs timeout value in milliseconds.
+     * @return a {@link Builder} object, for chaining
+     */
+    public Builder setReadRowsRpcTimeoutMs(int readStreamRpcTimeoutMs){
+      Preconditions.checkArgument(readStreamRpcTimeoutMs > 0, "Read Stream Timeout ms has to be greater than 0");
+      this.readRowsRpcTimeoutMs = readStreamRpcTimeoutMs;
+      return this;
+    }
+
     public CallOptionsConfig build() {
-      return new CallOptionsConfig(useTimeout, shortRpcTimeoutMs, longRpcTimeoutMs);
+      return new CallOptionsConfig(this);
     }
   }
 
   private final boolean useTimeout;
   private final int shortRpcTimeoutMs;
   private final int longRpcTimeoutMs;
+  private final int mutateRpcTimeoutMs;
+  private final int readStreamRpcTimeoutMs;
 
   /**
    * Constructor for CallOptionsConfig.
@@ -127,12 +159,33 @@ public class CallOptionsConfig implements Serializable {
    * @param useTimeout a boolean.
    * @param unaryRpcTimeoutMs an int.
    * @param longRpcTimeoutMs an int.
+   *
+   * @deprecated Please use {@link #builder()}
    */
   @Deprecated
   public CallOptionsConfig(boolean useTimeout, int unaryRpcTimeoutMs, int longRpcTimeoutMs) {
     this.useTimeout = useTimeout;
     this.shortRpcTimeoutMs = unaryRpcTimeoutMs;
     this.longRpcTimeoutMs = longRpcTimeoutMs;
+    this.mutateRpcTimeoutMs = longRpcTimeoutMs;
+    this.readStreamRpcTimeoutMs = longRpcTimeoutMs;
+  }
+
+  private CallOptionsConfig(Builder builder) {
+    this.useTimeout = builder.useTimeout;
+    this.shortRpcTimeoutMs = builder.shortRpcTimeoutMs;
+    this.longRpcTimeoutMs = builder.longRpcTimeoutMs;
+    int mutateTimeout = builder.mutateRpcTimeoutMs;
+    int readRowsTimeout = builder.readRowsRpcTimeoutMs;
+
+    if (mutateTimeout == LONG_TIMEOUT_MS_DEFAULT && longRpcTimeoutMs != LONG_TIMEOUT_MS_DEFAULT) {
+      mutateTimeout = longRpcTimeoutMs;
+    }
+    if (readRowsTimeout == LONG_TIMEOUT_MS_DEFAULT && longRpcTimeoutMs != LONG_TIMEOUT_MS_DEFAULT) {
+      readRowsTimeout = longRpcTimeoutMs;
+    }
+    this.mutateRpcTimeoutMs = mutateTimeout;
+    this.readStreamRpcTimeoutMs = readRowsTimeout;
   }
 
   /**
@@ -168,9 +221,30 @@ public class CallOptionsConfig implements Serializable {
    * Getter for the field <code>longRpcTimeoutMs</code>.
    *
    * @return an int.
+   *
+   * @deprecated Please use {@link #getMutateRpcTimeoutMs()} or {@link #getReadStreamRpcTimeoutMs()}.
    */
+  @Deprecated
   public int getLongRpcTimeoutMs() {
     return longRpcTimeoutMs;
+  }
+
+  /**
+   * <p>Getter for the field <code>mutateRpcTimeoutMs</code>.</p>
+   *
+   * @return an int.
+   */
+  public int getMutateRpcTimeoutMs() {
+    return mutateRpcTimeoutMs;
+  }
+
+  /**
+   * <p>Getter for the field <code>readStreamRpcTimeoutMs</code>.</p>
+   *
+   * @return an int.
+   */
+  public int getReadStreamRpcTimeoutMs() {
+    return readStreamRpcTimeoutMs;
   }
 
   /** {@inheritDoc} */
@@ -185,7 +259,9 @@ public class CallOptionsConfig implements Serializable {
     CallOptionsConfig other = (CallOptionsConfig) obj;
     return useTimeout == other.useTimeout
         && shortRpcTimeoutMs == other.shortRpcTimeoutMs
-        && longRpcTimeoutMs == other.longRpcTimeoutMs;
+        && longRpcTimeoutMs == other.longRpcTimeoutMs
+        && mutateRpcTimeoutMs == other.mutateRpcTimeoutMs
+        && readStreamRpcTimeoutMs == other.readStreamRpcTimeoutMs;
   }
 
   /** {@inheritDoc} */
@@ -195,6 +271,8 @@ public class CallOptionsConfig implements Serializable {
         .add("useTimeout", useTimeout)
         .add("shortRpcTimeoutMs", shortRpcTimeoutMs)
         .add("longRpcTimeoutMs", longRpcTimeoutMs)
+        .add("mutateRpcTimeoutMs", mutateRpcTimeoutMs)
+        .add("readStreamRpcTimeoutMs", readStreamRpcTimeoutMs)
         .toString();
   }
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/CallOptionsFactory.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/CallOptionsFactory.java
@@ -26,8 +26,7 @@ import io.grpc.MethodDescriptor;
 import java.util.concurrent.TimeUnit;
 
 /**
- * A factory that creates {@link io.grpc.CallOptions} for use in {@link
- * com.google.cloud.bigtable.grpc.BigtableDataClient} RPCs.
+ * A factory that creates {@link CallOptions} for use in {@link BigtableDataClient} RPCs.
  *
  * @author sduskis
  * @version $Id: $Id
@@ -35,10 +34,9 @@ import java.util.concurrent.TimeUnit;
 public interface CallOptionsFactory {
 
   /**
-   * Provide a {@link io.grpc.CallOptions} object to be used in a single RPC. {@link
-   * io.grpc.CallOptions} can contain state, specifically start time with an expiration is set; in
-   * cases when timeouts are used, implementations should create a new CallOptions each time this
-   * method is called.
+   * Provide a {@link CallOptions} object to be used in a single RPC. {@link CallOptions} can
+   * contain state, specifically start time with an expiration is set; in cases when timeouts are
+   * used, implementations should create a new CallOptions each time this method is called.
    *
    * @param descriptor The RPC that's being called. Different methods have different performance
    *     characteristics, so this parameter can be useful to craft the right timeout for the right
@@ -47,7 +45,7 @@ public interface CallOptionsFactory {
    *     request. The request can be for either a single row, or a range. This parameter can be used
    *     to tune timeouts
    * @param <RequestT> a RequestT object.
-   * @return a {@link io.grpc.CallOptions} object.
+   * @return a {@link CallOptions} object.
    */
   <RequestT> CallOptions create(MethodDescriptor<RequestT, ?> descriptor, RequestT request);
 
@@ -76,9 +74,8 @@ public interface CallOptionsFactory {
       this.config = config;
     }
 
-    @Override
     /**
-     * Creates a {@link CallOptions} with a focus on {@link Deadlines}. Deadlines are decided in the
+     * Creates a {@link CallOptions} with a focus on {@link Deadline}. Deadlines are decided in the
      * following order:
      *
      * <ol>
@@ -87,6 +84,7 @@ public interface CallOptionsFactory {
      *   <li>Otherwise, use {@link CallOptions#DEFAULT}.
      * </ol>
      */
+    @Override
     public <RequestT> CallOptions create(
         MethodDescriptor<RequestT, ?> descriptor, RequestT request) {
       Deadline contextDeadline = Context.current().getDeadline();
@@ -111,6 +109,21 @@ public interface CallOptionsFactory {
         return config.getMutateRpcTimeoutMs();
       } else {
         return config.getShortRpcTimeoutMs();
+      }
+    }
+
+    /**
+     * @param request
+     * @return true if this is a {@link MutateRowsRequest} or a {@link ReadRowsRequest} that's a
+     *     scan.
+     * @deprecated Please use {@link #getRequestTimeout(Object)} to fetch long requests timeout.
+     */
+    @Deprecated
+    public static boolean isLongRequest(Object request) {
+      if (request instanceof ReadRowsRequest) {
+        return !isGet((ReadRowsRequest) request);
+      } else {
+        return request instanceof MutateRowsRequest;
       }
     }
 

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestCallOptionsFactory.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestCallOptionsFactory.java
@@ -17,6 +17,7 @@ package com.google.cloud.bigtable.grpc;
 
 import com.google.bigtable.v2.MutateRowRequest;
 import com.google.bigtable.v2.MutateRowsRequest;
+import com.google.bigtable.v2.ReadRowsRequest;
 import com.google.cloud.bigtable.config.CallOptionsConfig;
 import com.google.cloud.bigtable.grpc.async.OperationClock;
 import io.grpc.CallOptions;
@@ -77,14 +78,21 @@ public class TestCallOptionsFactory {
 
   @Test
   public void testConfiguredConfigEnabled() {
-    CallOptionsConfig config = CallOptionsConfig.builder().setUseTimeout(true).build();
+    int readRowsTimeout = 500_000;
+    CallOptionsConfig config =
+        CallOptionsConfig.builder()
+            .setUseTimeout(true)
+            .setReadRowsRpcTimeoutMs(readRowsTimeout)
+            .build();
     CallOptionsFactory factory = new CallOptionsFactory.ConfiguredCallOptionsFactory(config);
     assertEqualsDeadlines(
         config.getShortRpcTimeoutMs(),
         getDeadlineMs(factory, MutateRowRequest.getDefaultInstance()));
     assertEqualsDeadlines(
-        config.getLongRpcTimeoutMs(),
+        config.getMutateRpcTimeoutMs(),
         getDeadlineMs(factory, MutateRowsRequest.getDefaultInstance()));
+    assertEqualsDeadlines(
+        readRowsTimeout, getDeadlineMs(factory, ReadRowsRequest.getDefaultInstance()));
   }
 
   @Test
@@ -100,7 +108,8 @@ public class TestCallOptionsFactory {
                 CallOptionsConfig.builder()
                     .setUseTimeout(true)
                     .setShortRpcTimeoutMs((int) TimeUnit.SECONDS.toMillis(100))
-                    .setLongRpcTimeoutMs((int) TimeUnit.SECONDS.toMillis(1000))
+                    .setMutateRpcTimeoutMs((int) TimeUnit.SECONDS.toMillis(1000))
+                    .setReadRowsRpcTimeoutMs((int) TimeUnit.SECONDS.toMillis(1000))
                     .build();
             CallOptionsFactory factory =
                 new CallOptionsFactory.ConfiguredCallOptionsFactory(config);

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
@@ -258,8 +258,23 @@ public class BigtableOptionsFactory {
    * If timeouts are set, how many milliseconds should pass before a DEADLINE_EXCEEDED for a long
    * read? Currently, this feature is experimental.
    */
+  @Deprecated
   public static final String BIGTABLE_LONG_RPC_TIMEOUT_MS_KEY =
       "google.bigtable.long.rpc.timeout.ms";
+
+  /**
+   * If timeouts are set, how many milliseconds should pass before a DEADLINE_EXCEEDED for a long
+   * mutation. Currently, this feature is experimental.
+   */
+  public static final String BIGTABLE_MUTATE_RPC_TIMEOUT_MS_KEY =
+      "google.bigtable.mutate.rpc.timeout.ms";
+
+  /**
+   * If timeouts are set, how many milliseconds should pass before a DEADLINE_EXCEEDED for a long
+   * read. Currently, this feature is experimental.
+   */
+  public static final String BIGTABLE_READ_RPC_TIMEOUT_MS_KEY =
+      "google.bigtable.read.rpc.timeout.ms";
 
   /** Allow namespace methods to be no-ops */
   public static final String BIGTABLE_NAMESPACE_WARNING_KEY = "google.bigtable.namespace.warnings";
@@ -453,8 +468,12 @@ public class BigtableOptionsFactory {
         configuration.getBoolean(BIGTABLE_USE_TIMEOUTS_KEY, USE_TIMEOUT_DEFAULT));
     clientCallOptionsBuilder.setShortRpcTimeoutMs(
         configuration.getInt(BIGTABLE_RPC_TIMEOUT_MS_KEY, SHORT_TIMEOUT_MS_DEFAULT));
-    clientCallOptionsBuilder.setLongRpcTimeoutMs(
-        configuration.getInt(BIGTABLE_LONG_RPC_TIMEOUT_MS_KEY, LONG_TIMEOUT_MS_DEFAULT));
+    int longTimeoutMs =
+        configuration.getInt(BIGTABLE_LONG_RPC_TIMEOUT_MS_KEY, LONG_TIMEOUT_MS_DEFAULT);
+    clientCallOptionsBuilder.setMutateRpcTimeoutMs(
+        configuration.getInt(BIGTABLE_MUTATE_RPC_TIMEOUT_MS_KEY, longTimeoutMs));
+    clientCallOptionsBuilder.setReadRowsRpcTimeoutMs(
+        configuration.getInt(BIGTABLE_READ_RPC_TIMEOUT_MS_KEY, longTimeoutMs));
     bigtableOptionsBuilder.setCallOptionsConfig(clientCallOptionsBuilder.build());
   }
 

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/BigtableOptionsFactory.java
@@ -257,6 +257,9 @@ public class BigtableOptionsFactory {
   /**
    * If timeouts are set, how many milliseconds should pass before a DEADLINE_EXCEEDED for a long
    * read? Currently, this feature is experimental.
+   *
+   * @deprecated Please use {@link #BIGTABLE_MUTATE_RPC_TIMEOUT_MS_KEY} or {@link
+   *     #BIGTABLE_READ_RPC_TIMEOUT_MS_KEY} based on long operation.
    */
   @Deprecated
   public static final String BIGTABLE_LONG_RPC_TIMEOUT_MS_KEY =

--- a/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableOptionsFactory.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/test/java/com/google/cloud/bigtable/hbase/TestBigtableOptionsFactory.java
@@ -15,6 +15,7 @@
  */
 package com.google.cloud.bigtable.hbase;
 
+import static com.google.cloud.bigtable.config.CallOptionsConfig.LONG_TIMEOUT_MS_DEFAULT;
 import static org.junit.Assert.assertEquals;
 
 import com.google.auth.Credentials;
@@ -31,8 +32,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import static com.google.cloud.bigtable.config.CallOptionsConfig.LONG_TIMEOUT_MS_DEFAULT;
 import org.mockito.Mockito;
 
 @RunWith(JUnit4.class)


### PR DESCRIPTION
Fixes #2156 

Introduced two new timeout fields in the `CallOptiosConfig` for each long request operation (i.e. `mutateRows` & `readRows`). This fields will also be defaults to `600 seconds` same as current `longRpcTimeoutMs`.

Deprecated`longRpcTimeoutMs`, If the user continues to use this then it can be translated into new fields.