### PR TITLE
Introducing google-cloud-bigtable-emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ infrequent product and client library announcements.
    mvn clean verify -PhbaseLocalMiniClusterTestH2
    ```
 
-
    You can run those commands at the top of the project, or you can run them at the appropriate integration-tests project.  
    
    Developer's NOTE: You can build the project faster by running the following command, and then run the integration test command from the appropriate integration test directory:
@@ -114,6 +113,31 @@ infrequent product and client library announcements.
    -am clean install
    ```
 3. Run `mvn -X com.coveo:fmt-maven-plugin:format` to check and enforce consistent java formatting to all of your code changes.
+
+4. You can use [google-cloud-bigtable-emulator][google-cloud-bigtable-emulator] for local testing. The minimum configuration requires to connect the emulator with `bigtable-core-client` OR `hbase-client`:
+    ```java
+    @Rule
+    public final BigtableEmulatorRule bigtableEmulator = BigtableEmulatorRule.create();
+    private BigtableSession session;
+    private Connection connection;
+    
+    @Setup
+    public void setup() {
+      // for bigtable-core
+      BigtableOptions opts = new BigtableOptions.Builder()
+            .enableEmulator("localhost:" + bigtableEmulator.getPort())
+            .setUserAgent("fake")
+            .setProjectId("fakeproject")
+            .setInstanceId("fakeinstance")
+            .build();
+      this.session = new BigtableSession(opts);
+    
+      // for hbase
+      Configuration config = BigtableConfiguration.configure("fakeproject", "fakeinstance");
+      config.set("google.bigtable.emulator.endpoint.host", "localhost:" + bigtableEmulator.getPort());
+      this.connection = BigtableConfiguration.connect(config);
+    }
+    ```
 
 NOTE: This project uses extensive shading which IDEs have trouble with. To overcome these issues,
 disable the `with-shaded` profile in your IDE to force it to resolve the dependencies from your local
@@ -161,3 +185,4 @@ Apache 2.0; see [LICENSE](LICENSE) for details.
 [maven-examples-repo]: https://github.com/GoogleCloudPlatform/cloud-bigtable-examples
 [google-cloud-bigtable-discuss]: https://groups.google.com/group/google-cloud-bigtable-discuss
 [google-cloud-bigtable-announce]: https://groups.google.com/group/google-cloud-bigtable-announce
+[google-cloud-bigtable-emulator]: https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-testing/google-cloud-bigtable-emulator

--- a/bigtable-test/bigtable-emulator-maven-plugin/README.md
+++ b/bigtable-test/bigtable-emulator-maven-plugin/README.md
@@ -9,7 +9,7 @@ It provides 3 maven goals:
 * stop: stops the emulator
 * run: like start, but runs the emulator in foreground
 
-_Note: You may check out [Google-cloud-Bigtable-emulator](#google-cloud-bigtable-emulator)._
+_Note: Please check out [Google-cloud-bigtable-emulator](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-testing/google-cloud-bigtable-emulator). It provides better set of features over `bigtable-emulator-maven-plugin` like JUnit `@Rule` support, Bundled binary, Programmatic control etc._ 
 
 Usage:
 
@@ -68,37 +68,3 @@ Usage:
    ```
 - If `maven.test.skip` is set to true the emulator will not start. The emulator can also be controlled directly 
   by setting the boolean property `bigtable.emulator.skip`.
-
-
-## [Google-cloud-Bigtable-emulator](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-testing/google-cloud-bigtable-emulator)
-
-  This is the latest bigtable emulator. It includes below features over `bigtable-emulator-maven-plugin`:
-  - Supports JUnit Rules
-  - Allows for direct programmatic control
-  - Bundles the emulator binary
-  - You can use a direct emulator wrapper as (i.e. [Emulator.java](https://github.com/googleapis/google-cloud-java/blob/master/google-cloud-testing/google-cloud-bigtable-emulator/src/main/java/com/google/cloud/bigtable/emulator/v2/Emulator.java))
-
-  Example with `Cloud-Bigtable-Client`:
-  ```java
-  @Rule
-  public final BigtableEmulatorRule bigtableEmulator = BigtableEmulatorRule.create();
-  private BigtableSession session;
-  private Connection connection;
-
-  @Setup
-  public void setup() {
-    // for bigtable-core
-    BigtableOptions opts = new BigtableOptions.Builder()
-          .enableEmulator("localhost:" + bigtableEmulator.getPort())
-          .setUserAgent("fake")
-          .setProjectId("fakeproject")
-          .setInstanceId("fakeinstance")
-          .build();
-    this.session = new BigtableSession(opts);
-
-    // for hbase
-    Configuration config = BigtableConfiguration.configure("fakeproject", "fakeinstance");
-    config.set("google.bigtable.emulator.endpoint.host", "localhost:" + bigtableEmulator.getPort());
-    this.connection = BigtableConfiguration.connect(config);
-  }
-  ```

--- a/bigtable-test/bigtable-emulator-maven-plugin/README.md
+++ b/bigtable-test/bigtable-emulator-maven-plugin/README.md
@@ -9,6 +9,7 @@ It provides 3 maven goals:
 * stop: stops the emulator
 * run: like start, but runs the emulator in foreground
 
+_Note: You may check out [Google-cloud-Bigtable-emulator](#google-cloud-bigtable-emulator)._
 
 Usage:
 
@@ -63,7 +64,41 @@ Usage:
   ```
   Or, for hbase:
   ```java
-      Connection connection = BigtableConfiguration.connect("fakeproject", "fakeinstace");
+      Connection connection = BigtableConfiguration.connect("fakeproject", "fakeinstance");
    ```
 - If `maven.test.skip` is set to true the emulator will not start. The emulator can also be controlled directly 
   by setting the boolean property `bigtable.emulator.skip`.
+
+
+## [Google-cloud-Bigtable-emulator](https://github.com/googleapis/google-cloud-java/tree/master/google-cloud-testing/google-cloud-bigtable-emulator)
+
+  This is the latest bigtable emulator. It includes below features over `bigtable-emulator-maven-plugin`:
+  - Supports JUnit Rules
+  - Allows for direct programmatic control
+  - Bundles the emulator binary
+  - You can use a direct emulator wrapper as (i.e. [Emulator.java](https://github.com/googleapis/google-cloud-java/blob/master/google-cloud-testing/google-cloud-bigtable-emulator/src/main/java/com/google/cloud/bigtable/emulator/v2/Emulator.java))
+
+  Example with `Cloud-Bigtable-Client`:
+  ```java
+  @Rule
+  public final BigtableEmulatorRule bigtableEmulator = BigtableEmulatorRule.create();
+  private BigtableSession session;
+  private Connection connection;
+
+  @Setup
+  public void setup() {
+    // for bigtable-core
+    BigtableOptions opts = new BigtableOptions.Builder()
+          .enableEmulator("localhost:" + bigtableEmulator.getPort())
+          .setUserAgent("fake")
+          .setProjectId("fakeproject")
+          .setInstanceId("fakeinstance")
+          .build();
+    this.session = new BigtableSession(opts);
+
+    // for hbase
+    Configuration config = BigtableConfiguration.configure("fakeproject", "fakeinstance");
+    config.set("google.bigtable.emulator.endpoint.host", "localhost:" + bigtableEmulator.getPort());
+    this.connection = BigtableConfiguration.connect(config);
+  }
+  ```


### PR DESCRIPTION
Fixes #1957 

## What this PR contains:
- Added instruction to programmatically set host & port in case of running this client in containers.
- Introduced new Google-cloud-emulator (inspired by [this](https://github.com/googleapis/cloud-bigtable-client/pull/2157#issuecomment-491359555) comment).