### PR TITLE
Changed Throwable logs to debug level to reduce unwanted logs in build

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/grpc/BigtableSession.java
@@ -639,8 +639,8 @@ public class BigtableSession implements Closeable {
       String host, BigtableOptions options, ClientInterceptor... interceptors) throws SSLException {
 
     LOG.info("Creating new channel for %s", host);
-    if (LOG.getLog().isDebugEnabled()) {
-      LOG.debug(Throwables.getStackTraceAsString(new Throwable()));
+    if (LOG.getLog().isTraceEnabled()) {
+      LOG.trace(Throwables.getStackTraceAsString(new Throwable()));
     }
 
     // Ideally, this should be ManagedChannelBuilder.forAddress(...) rather than an explicit


### PR DESCRIPTION
Line#643 was creating a lot of exception log in the build-log, It turns out this is originated from [hbase-2x-config](https://github.com/googleapis/cloud-bigtable-client/blob/master/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/resources/log4j.properties#L24).

@igorbernstein2, Please let me know your view on this. Not sure if just a cleaner build log is good enough reason for this change.