### PR TITLE
Added Bigtable client version info in Beam DisplayData

### DIFF
--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableConfiguration.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/main/java/com/google/cloud/bigtable/beam/CloudBigtableConfiguration.java
@@ -16,6 +16,7 @@
 package com.google.cloud.bigtable.beam;
 
 import com.google.bigtable.repackaged.com.google.cloud.bigtable.config.BigtableOptions;
+import com.google.bigtable.repackaged.com.google.cloud.bigtable.config.BigtableVersionInfo;
 import com.google.bigtable.repackaged.com.google.common.base.Preconditions;
 import com.google.bigtable.repackaged.com.google.common.collect.ImmutableMap;
 import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
@@ -320,6 +321,9 @@ public class CloudBigtableConfiguration implements Serializable {
                 "instanceId",
                 getDisplayValue(configuration.get(BigtableOptionsFactory.INSTANCE_ID_KEY)))
             .withLabel("Instance ID"));
+    builder.add(
+        DisplayData.item("bigtableClientVersion", BigtableVersionInfo.CLIENT_VERSION)
+            .withLabel("Bigtable Client Version"));
     Map<String, ValueProvider<String>> hashMap =
         new HashMap<String, ValueProvider<String>>(configuration);
     hashMap.remove(BigtableOptionsFactory.PROJECT_ID_KEY);

--- a/bigtable-dataflow-parent/bigtable-hbase-beam/src/test/java/com/google/cloud/bigtable/beam/CloudBigtableConfigurationTest.java
+++ b/bigtable-dataflow-parent/bigtable-hbase-beam/src/test/java/com/google/cloud/bigtable/beam/CloudBigtableConfigurationTest.java
@@ -19,6 +19,7 @@ package com.google.cloud.bigtable.beam;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 
+import com.google.bigtable.repackaged.com.google.cloud.bigtable.config.BigtableVersionInfo;
 import com.google.cloud.bigtable.beam.CloudBigtableConfiguration.Builder;
 import com.google.cloud.bigtable.hbase.BigtableOptionsFactory;
 import java.util.ArrayList;
@@ -173,6 +174,7 @@ public class CloudBigtableConfigurationTest {
     expected.add("null:google.bigtable.project.id=my_project");
     expected.add("null:google.bigtable.instance.id=instance");
     expected.add("null:inaccessible=Unavailable during pipeline construction");
+    expected.add("null:bigtableClientVersion=" + BigtableVersionInfo.CLIENT_VERSION);
 
     Assert.assertThat(builder.itemStrings, containsInAnyOrder(expected.toArray()));
   }


### PR DESCRIPTION
closes #1502 

Added `BigtableVersionInfo.CLIENT_VERSION` in `CloudBigtableConfiguration#populateDisplayData`.