### PR TITLE
Updated `AbstractBigtableTable#put` to include latency metrics

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/AbstractBigtableTable.java
@@ -338,8 +338,10 @@ public abstract class AbstractBigtableTable implements Table {
   @Override
   public void put(Put put) throws IOException {
     LOG.trace("put(Put)");
-    RowMutation rowMutation = hbaseAdapter.adapt(put);
-    mutateRow(put, rowMutation, "put");
+    try (Timer.Context ignored = metrics.putTimer.time()) {
+      RowMutation rowMutation = hbaseAdapter.adapt(put);
+      mutateRow(put, rowMutation, "put");
+    }
   }
 
   /** {@inheritDoc} */


### PR DESCRIPTION
adding this fix as I am not sure the reason behind having an unused Timer.