### PR TITLE
Updating GCJ dependency with latest GCJ version

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -169,7 +169,7 @@ limitations under the License.
             <exclusions>
                 <exclusion>
                     <groupId>io.grpc</groupId>
-                    <artifactId>*</artifactId>
+                    <artifactId>grpc-grpclb</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/bigtable-client-core-parent/bigtable-client-core/pom.xml
+++ b/bigtable-client-core-parent/bigtable-client-core/pom.xml
@@ -166,12 +166,6 @@ limitations under the License.
         <dependency>
             <groupId>com.google.api</groupId>
             <artifactId>gax-grpc</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>grpc-grpclb</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- Metrics -->

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestHeaders.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/grpc/TestHeaders.java
@@ -186,18 +186,20 @@ public class TestHeaders {
     final String endpoint = "localhost" + ":" + availablePort;
     HeaderProvider headers = FixedHeaderProvider.create(USER_AGENT_KEY.name(), TEST_USER_AGENT);
 
-    builder.setTransportChannelProvider(
-        InstantiatingGrpcChannelProvider.newBuilder()
-            .setHeaderProvider(headers)
-            .setEndpoint(endpoint)
-            .setChannelConfigurator(
-                new ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder>() {
-                  @Override
-                  public ManagedChannelBuilder apply(ManagedChannelBuilder input) {
-                    return ((NettyChannelBuilder) input).sslContext(sslContext);
-                  }
-                })
-            .build());
+    builder
+        .stubSettings()
+        .setTransportChannelProvider(
+            InstantiatingGrpcChannelProvider.newBuilder()
+                .setHeaderProvider(headers)
+                .setEndpoint(endpoint)
+                .setChannelConfigurator(
+                    new ApiFunction<ManagedChannelBuilder, ManagedChannelBuilder>() {
+                      @Override
+                      public ManagedChannelBuilder apply(ManagedChannelBuilder input) {
+                        return ((NettyChannelBuilder) input).sslContext(sslContext);
+                      }
+                    })
+                .build());
 
     // Setting this to null, because as of 3/4/2019 the header doesn't get passed through.
     xGoogApiPattern = null;

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@ limitations under the License.
         <hamcrest.version>1.3</hamcrest.version>
 
         <!-- google-cloud-java related dependency versions -->
-        <google-cloud.version>0.94.0-alpha</google-cloud.version>
+        <google-cloud.version>0.97.0-alpha</google-cloud.version>
         <opencensus.version>0.21.0</opencensus.version>
         <guava.version>27.1-android</guava.version>
         <checkerframework.version>2.5.2</checkerframework.version>


### PR DESCRIPTION
After updating to `google-cloud-java:0.97.0`, I started to see ClassNotFoundException while creating GCJ connection:
```java
java.lang.ClassNotFoundException: io.grpc.alts.ComputeEngineChannelBuilder
```

For this, we require `grpc-alts` which is transitively coming from `gax-grpc`
```sh
[INFO] |  +- com.google.api:gax-grpc:jar:1.46.1:compile
[INFO] |  |  +- com.google.api:gax:jar:1.46.1:compile
[INFO] |  |  +- org.threeten:threetenbp:jar:1.3.3:compile
[INFO] |  |  \- io.grpc:grpc-alts:jar:1.21.0:compile
[INFO] |  |     +- io.grpc:grpc-grpclb:jar:1.21.0:compile
[INFO] |  |     \- org.apache.commons:commons-lang3:jar:3.5:compile
```

To fix this issue, I've excluded the only other grpc jar(i.e `grpc-grpclb`) from this instead of excluding all grpc jars. I hope this should not create any unknown dependency problem for `bigtable-core`.