### PR TITLE
Fix for long pauses and unauthentication issue with batch endpoint

### DIFF
--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/BigtableOptions.java
@@ -274,11 +274,15 @@ public class BigtableOptions implements Serializable, Cloneable {
       } else {
         options.instanceName = null;
       }
+      if (options.dataHost.equals(BIGTABLE_BATCH_DATA_HOST_DEFAULT)) {
+        options.credentialOptions.useBatchMode();
+      }
 
       if (options.useBatch) {
         options.useCachedDataPool = true;
         if (options.dataHost.equals(BIGTABLE_DATA_HOST_DEFAULT)) {
           options.dataHost = BIGTABLE_BATCH_DATA_HOST_DEFAULT;
+          options.credentialOptions.useBatchMode();
         }
         RetryOptions.Builder retryOptionsBuilder = options.retryOptions.toBuilder();
         if (options.retryOptions.getInitialBackoffMillis()

--- a/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CredentialOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/main/java/com/google/cloud/bigtable/config/CredentialOptions.java
@@ -239,6 +239,7 @@ public class CredentialOptions implements Serializable {
   }
 
   private CredentialType credentialType;
+  private boolean isBatchMode;
 
   private CredentialOptions(CredentialType credentialType) {
     this.credentialType = credentialType;
@@ -253,6 +254,16 @@ public class CredentialOptions implements Serializable {
    */
   public CredentialType getCredentialType() {
     return credentialType;
+  }
+
+  /** Sets the experimental flag of identifying batch mode to true */
+  void useBatchMode() {
+    this.isBatchMode = true;
+  }
+
+  /** Getter for <code>isBatchMode</code> */
+  boolean isBatchMode() {
+    return isBatchMode;
   }
 
   /** {@inheritDoc} */

--- a/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/config/TestBigtableOptions.java
+++ b/bigtable-client-core-parent/bigtable-client-core/src/test/java/com/google/cloud/bigtable/config/TestBigtableOptions.java
@@ -132,6 +132,38 @@ public class TestBigtableOptions {
     Assert.assertEquals(300_000, options.getRetryOptions().getMaxElapsedBackoffMillis());
   }
 
+  @Test
+  public void testBatchMode() {
+    BigtableOptions optionsWithNullCredentials =
+        BigtableOptions.builder()
+            .setProjectId("project")
+            .setInstanceId("instance")
+            .setUserAgent("foo")
+            .setCredentialOptions(CredentialOptions.nullCredential())
+            .build();
+    Assert.assertFalse(optionsWithNullCredentials.getCredentialOptions().isBatchMode());
+
+    CredentialOptions credentialOptions = CredentialOptions.defaultCredentials();
+    Assert.assertFalse(credentialOptions.isBatchMode());
+    BigtableOptions optionsWithDefaultCred =
+        BigtableOptions.builder()
+            .setProjectId("project")
+            .setInstanceId("instance")
+            .setUserAgent("foo")
+            .setCredentialOptions(credentialOptions)
+            .setDataHost(BigtableOptions.BIGTABLE_BATCH_DATA_HOST_DEFAULT)
+            .build();
+    Assert.assertTrue(optionsWithDefaultCred.getCredentialOptions().isBatchMode());
+
+    BigtableOptions batchModeOptions =
+        BigtableOptions.builder()
+            .setProjectId("project")
+            .setInstanceId("instance")
+            .setUserAgent("foo")
+            .setUseBatch(true)
+            .build();
+    Assert.assertTrue(batchModeOptions.getCredentialOptions().isBatchMode());
+  }
   /**
    * This is a dirty way to override the environment that is accessible to a test. It only modifies
    * the JVM's view of the environment, not the environment itself. From:


### PR DESCRIPTION
**Issue:** When running batch operation, dataflow jobs are taking long pauses in case of dataflow jobs using `CloudBigtableIO` and logging a lot of un-authentication issue.

**Fix:** Now when the client is used with `batch-bigtable.googleapis.com` host, then only OAuth2 authentication would be used instead of using JWT token.

**Note:** This is a temporary workaround until the internal team fixes the issue. This commit may be reverted once fix is implemented.

@igorbernstein2 @kolea2 