### PR TITLE
Fix JWT auth with the batch endpoint.

### DIFF
--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/IntegrationTests.java
@@ -25,6 +25,7 @@ import org.junit.runners.Suite;
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
   TestAppend.class,
+  TestAuth.class,
   TestBasicOps.class,
   TestBatch.class,
   TestBufferedMutator.class,

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestAuth.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestAuth.java
@@ -1,0 +1,71 @@
+package com.google.cloud.bigtable.hbase;
+
+import com.google.bigtable.repackaged.com.google.auth.Credentials;
+import com.google.bigtable.repackaged.com.google.auth.oauth2.GoogleCredentials;
+import com.google.bigtable.repackaged.com.google.auth.oauth2.ServiceAccountCredentials;
+import com.google.bigtable.repackaged.com.google.auth.oauth2.ServiceAccountJwtAccessCredentials;
+import java.io.IOException;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Table;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TestAuth extends AbstractTest {
+  @Test
+  public void testBatchJwt() throws IOException {
+    Assume.assumeTrue("Batch JWT can only run against Bigtable", sharedTestEnv.isBigtable());
+
+    String currentEndpoint = sharedTestEnv.getConfiguration().get("google.bigtable.endpoint.host");
+    Assume.assumeTrue(
+        "Batch JWT test can only run in prod",
+        currentEndpoint == null || "bigtable.googleapis.com".equals(currentEndpoint));
+
+    Credentials credentials = GoogleCredentials.getApplicationDefault();
+
+    if (credentials instanceof ServiceAccountCredentials) {
+      ServiceAccountCredentials svcCreds = (ServiceAccountCredentials)credentials;
+      credentials = ServiceAccountJwtAccessCredentials.newBuilder()
+          .setClientId(svcCreds.getClientId())
+          .setClientEmail(svcCreds.getClientEmail())
+          .setPrivateKeyId(svcCreds.getPrivateKeyId())
+          .setPrivateKey(svcCreds.getPrivateKey())
+          .build();
+    }
+
+    Assume.assumeTrue("Service account credentials are required",
+        credentials instanceof ServiceAccountJwtAccessCredentials);
+
+
+    BigtableExtendedConfiguration config = new BigtableExtendedConfiguration(
+        sharedTestEnv.getConfiguration(),
+        credentials
+    );
+    config.set("google.bigtable.use.batch", "true");
+
+    // Prevent the test from hanging if auth fails
+    config.set("google.bigtable.rpc.use.timeouts", "true");
+    config.set("google.bigtable.rpc.timeout.ms", "10000");
+
+    // Create a new connection using JWT auth & batch settings
+    try (Connection connection = BigtableConfiguration.connect(config)) {
+      // Reuse the default test table
+      Table table = connection.getTable(sharedTestEnv.getDefaultTableName());
+      Exception actualError = null;
+
+      // Perform any RPC
+      try {
+        table.get(new Get("any-key".getBytes()));
+      } catch (Exception e) {
+        actualError = e;
+      }
+
+      // Verify that it succeeded.
+      Assert.assertNull("No error when getting a key with JWT", actualError);
+    }
+  }
+}

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestAuth.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestAuth.java
@@ -28,23 +28,22 @@ public class TestAuth extends AbstractTest {
     Credentials credentials = GoogleCredentials.getApplicationDefault();
 
     if (credentials instanceof ServiceAccountCredentials) {
-      ServiceAccountCredentials svcCreds = (ServiceAccountCredentials)credentials;
-      credentials = ServiceAccountJwtAccessCredentials.newBuilder()
-          .setClientId(svcCreds.getClientId())
-          .setClientEmail(svcCreds.getClientEmail())
-          .setPrivateKeyId(svcCreds.getPrivateKeyId())
-          .setPrivateKey(svcCreds.getPrivateKey())
-          .build();
+      ServiceAccountCredentials svcCreds = (ServiceAccountCredentials) credentials;
+      credentials =
+          ServiceAccountJwtAccessCredentials.newBuilder()
+              .setClientId(svcCreds.getClientId())
+              .setClientEmail(svcCreds.getClientEmail())
+              .setPrivateKeyId(svcCreds.getPrivateKeyId())
+              .setPrivateKey(svcCreds.getPrivateKey())
+              .build();
     }
 
-    Assume.assumeTrue("Service account credentials are required",
+    Assume.assumeTrue(
+        "Service account credentials are required",
         credentials instanceof ServiceAccountJwtAccessCredentials);
 
-
-    BigtableExtendedConfiguration config = new BigtableExtendedConfiguration(
-        sharedTestEnv.getConfiguration(),
-        credentials
-    );
+    BigtableExtendedConfiguration config =
+        new BigtableExtendedConfiguration(sharedTestEnv.getConfiguration(), credentials);
     config.set("google.bigtable.use.batch", "true");
 
     // Prevent the test from hanging if auth fails


### PR DESCRIPTION
gRPC sets the endpoint as the JWT audience, but the service expects the service name.
Until this is resolved on the serverside, wrap the JWT token in a shim that will fake the URI.