### PR TITLE
Remove optimization for zero copy row keys.

### DIFF
--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/FlatRowAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/FlatRowAdapter.java
@@ -41,7 +41,7 @@ public class FlatRowAdapter implements ResponseAdapter<FlatRow, Result> {
     if (flatRow == null || flatRow.getRowKey() == null) {
       return Result.EMPTY_RESULT;
     }
-    byte[] RowKey = ByteStringer.extract(flatRow.getRowKey());
+    byte[] RowKey = flatRow.getRowKey().toByteArray();
     List<FlatRow.Cell> cells = flatRow.getCells();
     List<Cell> hbaseCells = new ArrayList<>(cells.size());
     byte[] previousFamilyBytes = null;

--- a/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/RowAdapter.java
+++ b/bigtable-client-core-parent/bigtable-hbase/src/main/java/com/google/cloud/bigtable/hbase/adapters/read/RowAdapter.java
@@ -45,7 +45,7 @@ public class RowAdapter implements ResponseAdapter<Row, Result> {
     }
 
     SortedSet<Cell> hbaseCells = new TreeSet<>(KeyValue.COMPARATOR);
-    byte[] rowKey = ByteStringer.extract(response.getKey());
+    byte[] rowKey = response.getKey().toByteArray();
 
     for (com.google.cloud.bigtable.data.v2.models.RowCell rowCell : response.getCells()) {
 


### PR DESCRIPTION
If the caller modifies the row key array, it creates some very hard to debug issues in the RowMerger.