### PR TITLE
Updating GCJ and Guava version

### DIFF
--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestAuth.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestAuth.java
@@ -66,7 +66,8 @@ public class TestAuth extends AbstractTest {
 
     // Prevent the test from hanging if auth fails
     config.set("google.bigtable.rpc.use.timeouts", "true");
-    config.set("google.bigtable.rpc.timeout.ms", "20000");
+    config.set("google.bigtable.rpc.timeout.ms", "10000");
+    config.set("google.bigtable.grpc.channel.count", "1");
 
     // Create a new connection using JWT auth & batch settings
     try (Connection connection = BigtableConfiguration.connect(config)) {

--- a/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestAuth.java
+++ b/bigtable-hbase-1.x-parent/bigtable-hbase-1.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestAuth.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.cloud.bigtable.hbase;
 
 import com.google.bigtable.repackaged.com.google.auth.Credentials;
@@ -19,6 +34,9 @@ public class TestAuth extends AbstractTest {
   @Test
   public void testBatchJwt() throws IOException {
     Assume.assumeTrue("Batch JWT can only run against Bigtable", sharedTestEnv.isBigtable());
+    Assume.assumeFalse(
+        "GCJ client does not support cachedDataPool",
+        Boolean.getBoolean("google.bigtable.use.gcj.client"));
 
     String currentEndpoint = sharedTestEnv.getConfiguration().get("google.bigtable.endpoint.host");
     Assume.assumeTrue(
@@ -48,7 +66,7 @@ public class TestAuth extends AbstractTest {
 
     // Prevent the test from hanging if auth fails
     config.set("google.bigtable.rpc.use.timeouts", "true");
-    config.set("google.bigtable.rpc.timeout.ms", "10000");
+    config.set("google.bigtable.rpc.timeout.ms", "20000");
 
     // Create a new connection using JWT auth & batch settings
     try (Connection connection = BigtableConfiguration.connect(config)) {

--- a/pom.xml
+++ b/pom.xml
@@ -58,9 +58,9 @@ limitations under the License.
         <hamcrest.version>1.3</hamcrest.version>
 
         <!-- google-cloud-java related dependency versions -->
-        <google-cloud.version>0.97.0-alpha</google-cloud.version>
+        <google-cloud.version>0.102.0-alpha</google-cloud.version>
         <opencensus.version>0.21.0</opencensus.version>
-        <guava.version>27.1-android</guava.version>
+        <guava.version>28.0-android</guava.version>
         <checkerframework.version>2.5.2</checkerframework.version>
 
         <!-- hbase dependency versions -->
@@ -233,7 +233,7 @@ limitations under the License.
                     <execution>
                         <phase>process-sources</phase>
                         <goals>
-                            <goal>check</goal>
+                            <goal>format</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@ limitations under the License.
                     <execution>
                         <phase>process-sources</phase>
                         <goals>
-                            <goal>format</goal>
+                            <goal>check</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -58,9 +58,8 @@ limitations under the License.
         <hamcrest.version>1.3</hamcrest.version>
 
         <!-- google-cloud-java related dependency versions -->
-        <google-cloud.version>0.102.0-alpha</google-cloud.version>
+        <google-cloud.version>0.103.0-alpha</google-cloud.version>
         <opencensus.version>0.21.0</opencensus.version>
-        <guava.version>28.0-android</guava.version>
         <checkerframework.version>2.5.2</checkerframework.version>
 
         <!-- hbase dependency versions -->
@@ -74,6 +73,8 @@ limitations under the License.
         <mockito.version>2.25.1</mockito.version>
 
         <beam.version>2.11.0</beam.version>
+        <!-- referred from bigtable-beam-import and bigtable-emulator -->
+        <guava.version>28.0-android</guava.version>
     </properties>
 
     <distributionManagement>


### PR DESCRIPTION
- Added `Assert#assume` to cover IT test with `useGCJClient` flag.
- Increase RPC timeout to 20seconds(It was failing on my system).
- Updated GCJ client version.
- Updated `fmt-format-plugin` to auto-format instead of format check(This will not affect pre-submit format check present for travis).

CC: @igorbernstein2 @kolea2 
Please have a look