### PR TITLE
Updating Hbase version to latest( 1x: 1.4.10, 2x: 2.2.0)

### DIFF
--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestCreateTableHBase2.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/TestCreateTableHBase2.java
@@ -24,8 +24,23 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
 import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.junit.Assert;
+import org.junit.Test;
 
 public class TestCreateTableHBase2 extends AbstractTestCreateTable {
+
+  @Test
+  public void testCreateAsync() throws Exception {
+    TableName tableName = sharedTestEnv.newTestTableName();
+    createTableAsync(tableName);
+    Assert.assertTrue(tableExists(tableName));
+    deleteTable(tableName);
+    Assert.assertFalse(tableExists(tableName));
+  }
+
+  private void createTableAsync(TableName tableName) throws Exception {
+    getConnection().getAdmin().createTableAsync(createDescriptor(tableName)).get();
+  }
 
   @Override
   protected void createTable(TableName tableName) throws IOException {

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncAdmin.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncAdmin.java
@@ -143,7 +143,7 @@ public class TestAsyncAdmin extends AbstractAsyncTest {
         asyncAdmin.listTableDescriptors(null).get();
         fail("listTableDescriptors should throw an exception");
       } catch (Exception e) {
-        Assert.assertTrue(e instanceof NullPointerException);
+        assertTrue(e instanceof NullPointerException);
       }
 
       List<TableDescriptor> emptyListDescriptor =
@@ -165,10 +165,10 @@ public class TestAsyncAdmin extends AbstractAsyncTest {
           .filter(
               td -> td.getTableName().getNameAsString().equals(anotherTableName.getNameAsString()))
           .forEach(
-              matchT -> {
-                assertEquals(2, matchT.getColumnFamilyCount());
-                assertArrayEquals(COLUMN_FAMILY, matchT.getColumnFamily(COLUMN_FAMILY).getName());
-                assertArrayEquals(COLUMN_FAMILY2, matchT.getColumnFamily(COLUMN_FAMILY2).getName());
+              mTable -> {
+                assertEquals(2, mTable.getColumnFamilyCount());
+                assertArrayEquals(COLUMN_FAMILY, mTable.getColumnFamily(COLUMN_FAMILY).getName());
+                assertArrayEquals(COLUMN_FAMILY2, mTable.getColumnFamily(COLUMN_FAMILY2).getName());
               });
 
       // test getTableDescriptor

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x-integration-tests/src/test/java/com/google/cloud/bigtable/hbase/async/TestAsyncConnection.java
@@ -72,4 +72,9 @@ public class TestAsyncConnection extends AbstractAsyncTest {
             .getBufferedMutatorBuilder(sharedTestEnv.getDefaultTableName(), directExecutorService)
             .build());
   }
+
+  @Test
+  public void testConnectionIsClosed() throws Exception {
+    Assert.assertFalse("Connection should open at this point", getAsyncConnection().isClosed());
+  }
 }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAdmin.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAdmin.java
@@ -57,9 +57,13 @@ import org.apache.hadoop.hbase.client.security.SecurityCapability;
 import org.apache.hadoop.hbase.quotas.QuotaFilter;
 import org.apache.hadoop.hbase.quotas.QuotaRetriever;
 import org.apache.hadoop.hbase.quotas.QuotaSettings;
+import org.apache.hadoop.hbase.quotas.SpaceQuotaSnapshotView;
 import org.apache.hadoop.hbase.replication.ReplicationException;
 import org.apache.hadoop.hbase.replication.ReplicationPeerConfig;
 import org.apache.hadoop.hbase.replication.ReplicationPeerDescription;
+import org.apache.hadoop.hbase.security.access.GetUserPermissionsRequest;
+import org.apache.hadoop.hbase.security.access.Permission;
+import org.apache.hadoop.hbase.security.access.UserPermission;
 import org.apache.hadoop.hbase.snapshot.HBaseSnapshotException;
 import org.apache.hadoop.hbase.snapshot.RestoreSnapshotException;
 import org.apache.hadoop.hbase.snapshot.SnapshotCreationException;
@@ -98,6 +102,11 @@ public class BigtableAdmin extends AbstractBigtableAdmin {
   @Override
   public void createTable(TableDescriptor desc, byte[][] splitKeys) throws IOException {
     createTable(desc.getTableName(), TableAdapter2x.adapt(desc, splitKeys));
+  }
+
+  @Override
+  public Future<Void> createTableAsync(TableDescriptor tableDescriptor) throws IOException {
+    return asyncAdmin.createTable(tableDescriptor);
   }
 
   /** {@inheritDoc} */
@@ -422,6 +431,66 @@ public class BigtableAdmin extends AbstractBigtableAdmin {
   }
 
   @Override
+  public boolean switchRpcThrottle(boolean enable) throws IOException {
+    throw new UnsupportedOperationException("switchRpcThrottle");
+  }
+
+  @Override
+  public boolean isRpcThrottleEnabled() throws IOException {
+    throw new UnsupportedOperationException("isRpcThrottleEnabled");
+  }
+
+  @Override
+  public boolean exceedThrottleQuotaSwitch(boolean b) throws IOException {
+    throw new UnsupportedOperationException("exceedThrottleQuotaSwitch");
+  }
+
+  @Override
+  public Map<TableName, Long> getSpaceQuotaTableSizes() throws IOException {
+    throw new UnsupportedOperationException("getSpaceQuotaTableSizes");
+  }
+
+  @Override
+  public Map<TableName, ? extends SpaceQuotaSnapshotView> getRegionServerSpaceQuotaSnapshots(
+      ServerName serverName) throws IOException {
+    throw new UnsupportedOperationException("getRegionServerSpaceQuotaSnapshots");
+  }
+
+  @Override
+  public SpaceQuotaSnapshotView getCurrentSpaceQuotaSnapshot(String namespace) throws IOException {
+    throw new UnsupportedOperationException("getCurrentSpaceQuotaSnapshot");
+  }
+
+  @Override
+  public SpaceQuotaSnapshotView getCurrentSpaceQuotaSnapshot(TableName tableName)
+      throws IOException {
+    throw new UnsupportedOperationException("getCurrentSpaceQuotaSnapshot");
+  }
+
+  @Override
+  public void grant(UserPermission userPermission, boolean mergeExistingPermissions)
+      throws IOException {
+    throw new UnsupportedOperationException("grant");
+  }
+
+  @Override
+  public void revoke(UserPermission userPermission) throws IOException {
+    throw new UnsupportedOperationException("revoke");
+  }
+
+  @Override
+  public List<UserPermission> getUserPermissions(
+      GetUserPermissionsRequest getUserPermissionsRequest) throws IOException {
+    throw new UnsupportedOperationException("getUserPermissions");
+  }
+
+  @Override
+  public List<Boolean> hasUserPermissions(String userName, List<Permission> permissions)
+      throws IOException {
+    throw new UnsupportedOperationException("hasUserPermissions");
+  }
+
+  @Override
   public void compact(TableName arg0, CompactType arg1) throws IOException, InterruptedException {
     throw new UnsupportedOperationException("compact");
   }
@@ -588,8 +657,19 @@ public class BigtableAdmin extends AbstractBigtableAdmin {
   }
 
   @Override
+  public Map<ServerName, Boolean> compactionSwitch(
+      boolean switchState, List<String> serverNamesList) throws IOException {
+    throw new UnsupportedOperationException("compactionSwitch");
+  }
+
+  @Override
   public Future<Void> mergeRegionsAsync(byte[][] arg0, boolean arg1) throws IOException {
     throw new UnsupportedOperationException("mergeRegionsAsync"); // TODO
+  }
+
+  @Override
+  public Future<Void> splitRegionAsync(byte[] regionName) throws IOException {
+    throw new UnsupportedOperationException("splitRegionAsync");
   }
 
   @Override
@@ -735,6 +815,16 @@ public class BigtableAdmin extends AbstractBigtableAdmin {
   @Override
   public void majorCompactRegionServer(ServerName arg0) throws IOException {
     throw new UnsupportedOperationException("majorCompactRegionServer"); // TODO
+  }
+
+  @Override
+  public void move(byte[] encodedRegionName) throws IOException {
+    throw new UnsupportedOperationException("move");
+  }
+
+  @Override
+  public void move(byte[] encodedRegionName, ServerName destServerName) throws IOException {
+    throw new UnsupportedOperationException("move");
   }
 
   @Override

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncAdmin.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncAdmin.java
@@ -283,10 +283,13 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
                           try {
                             return getDescriptor(tbName).join();
                           } catch (CompletionException ex) {
-                            LOG.warn(
-                                "Table not found while fetching details for %s",
-                                ex, tbName.getNameAsString());
-                            return null;
+                            if (ex.getCause() instanceof TableNotFoundException) {
+                              LOG.warn(
+                                  "Table not found while fetching details for %s",
+                                  ex, tbName.getNameAsString());
+                              return null;
+                            }
+                            throw ex;
                           }
                         })
                     .filter(Objects::nonNull)

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncAdmin.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncAdmin.java
@@ -74,8 +74,12 @@ import org.apache.hadoop.hbase.client.replication.TableCFs;
 import org.apache.hadoop.hbase.client.security.SecurityCapability;
 import org.apache.hadoop.hbase.quotas.QuotaFilter;
 import org.apache.hadoop.hbase.quotas.QuotaSettings;
+import org.apache.hadoop.hbase.quotas.SpaceQuotaSnapshotView;
 import org.apache.hadoop.hbase.replication.ReplicationPeerConfig;
 import org.apache.hadoop.hbase.replication.ReplicationPeerDescription;
+import org.apache.hadoop.hbase.security.access.GetUserPermissionsRequest;
+import org.apache.hadoop.hbase.security.access.Permission;
+import org.apache.hadoop.hbase.security.access.UserPermission;
 import org.apache.hadoop.hbase.shaded.com.google.protobuf.RpcChannel;
 import org.apache.hadoop.hbase.snapshot.RestoreSnapshotException;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -259,6 +263,27 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
     return listTables(Optional.of(pattern));
   }
 
+  @Override
+  public CompletableFuture<List<TableDescriptor>> listTableDescriptors(List<TableName> list) {
+    if (list == null || list.isEmpty()) {
+      return CompletableFuture.completedFuture(null);
+    }
+
+    return toCompletableFuture(bigtableTableAdminClient.listTablesAsync())
+        .thenApply(
+            t ->
+                list.stream()
+                    .filter(in -> t.contains(in.getNameAsString()))
+                    .map(
+                        m ->
+                            com.google.bigtable.admin.v2.Table.newBuilder()
+                                .setName(bigtableInstanceName.toTableNameStr(m.getNameAsString()))
+                                .build())
+                    .map(Table::fromProto)
+                    .map(tableAdapter2x::adapt)
+                    .collect(Collectors.toList()));
+  }
+
   /** {@inheritDoc} */
   @Override
   public CompletableFuture<Boolean> isTableDisabled(TableName tableName) {
@@ -427,6 +452,12 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
     return future;
   }
 
+  @Override
+  public CompletableFuture<Void> restoreSnapshot(
+      String snapshotName, boolean takeFailSafeSnapshot, boolean restoreAcl) {
+    throw new UnsupportedOperationException("restoreSnapshot");
+  }
+
   /**
    * To check Snapshot exists or not.
    *
@@ -529,6 +560,12 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
   }
 
   @Override
+  public CompletableFuture<Void> cloneSnapshot(
+      String snapshotName, TableName tableName, boolean restoreAcl) {
+    throw new UnsupportedOperationException("cloneSnapshot");
+  }
+
+  @Override
   public CompletableFuture<List<SnapshotDescription>> listSnapshots() {
     return CompletableFuture.supplyAsync(
             () -> {
@@ -584,6 +621,73 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
   public CompletableFuture<Void> cloneTableSchema(
       TableName tableName, TableName tableName1, boolean preserveSplits) {
     throw new UnsupportedOperationException("cloneTableSchema"); // TODO
+  }
+
+  @Override
+  public CompletableFuture<Map<ServerName, Boolean>> compactionSwitch(
+      boolean switchState, List<String> serverNamesList) {
+    throw new UnsupportedOperationException("compactionSwitch");
+  }
+
+  @Override
+  public CompletableFuture<Boolean> switchRpcThrottle(boolean enable) {
+    throw new UnsupportedOperationException("switchRpcThrottle");
+  }
+
+  @Override
+  public CompletableFuture<Boolean> isRpcThrottleEnabled() {
+    throw new UnsupportedOperationException("isRpcThrottleEnabled");
+  }
+
+  @Override
+  public CompletableFuture<Boolean> exceedThrottleQuotaSwitch(boolean enable) {
+    throw new UnsupportedOperationException("exceedThrottleQuotaSwitch");
+  }
+
+  @Override
+  public CompletableFuture<Map<TableName, Long>> getSpaceQuotaTableSizes() {
+    throw new UnsupportedOperationException("getSpaceQuotaTableSizes");
+  }
+
+  @Override
+  public CompletableFuture<? extends Map<TableName, ? extends SpaceQuotaSnapshotView>>
+      getRegionServerSpaceQuotaSnapshots(ServerName serverName) {
+    throw new UnsupportedOperationException("getRegionServerSpaceQuotaSnapshots");
+  }
+
+  @Override
+  public CompletableFuture<? extends SpaceQuotaSnapshotView> getCurrentSpaceQuotaSnapshot(
+      String namespace) {
+    throw new UnsupportedOperationException("getCurrentSpaceQuotaSnapshot");
+  }
+
+  @Override
+  public CompletableFuture<? extends SpaceQuotaSnapshotView> getCurrentSpaceQuotaSnapshot(
+      TableName tableName) {
+    throw new UnsupportedOperationException("getCurrentSpaceQuotaSnapshot");
+  }
+
+  @Override
+  public CompletableFuture<Void> grant(
+      UserPermission userPermission, boolean mergeExistingPermissions) {
+    throw new UnsupportedOperationException("grant");
+  }
+
+  @Override
+  public CompletableFuture<Void> revoke(UserPermission userPermission) {
+    throw new UnsupportedOperationException("revoke");
+  }
+
+  @Override
+  public CompletableFuture<List<UserPermission>> getUserPermissions(
+      GetUserPermissionsRequest getUserPermissionsRequest) {
+    throw new UnsupportedOperationException("getUserPermissions");
+  }
+
+  @Override
+  public CompletableFuture<List<Boolean>> hasUserPermissions(
+      String userName, List<Permission> permissions) {
+    throw new UnsupportedOperationException("hasUserPermissions");
   }
 
   @Override
@@ -829,6 +933,11 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
   }
 
   @Override
+  public CompletableFuture<Void> mergeRegions(List<byte[]> nameOfRegionsToMerge, boolean forcible) {
+    throw new UnsupportedOperationException("mergeRegions");
+  }
+
+  @Override
   public CompletableFuture<Void> modifyNamespace(NamespaceDescriptor arg0) {
     throw new UnsupportedOperationException("modifyNamespace"); // TODO
   }
@@ -950,6 +1059,11 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
   @Override
   public CompletableFuture<Boolean> balancerSwitch(boolean arg0) {
     throw new UnsupportedOperationException("balancerSwitch"); // TODO
+  }
+
+  @Override
+  public CompletableFuture<Boolean> balancerSwitch(boolean on, boolean drainRITs) {
+    throw new UnsupportedOperationException("balancerSwitch");
   }
 
   @Override
@@ -1122,6 +1236,11 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
   }
 
   @Override
+  public CompletableFuture<Boolean> mergeSwitch(boolean enabled, boolean drainMerges) {
+    throw new UnsupportedOperationException("mergeSwitch");
+  }
+
+  @Override
   public CompletableFuture<Void> move(byte[] arg0) {
     throw new UnsupportedOperationException("move"); // TODO
   }
@@ -1155,5 +1274,10 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
   @Override
   public CompletableFuture<Boolean> splitSwitch(boolean arg0) {
     throw new UnsupportedOperationException("splitSwitch"); // TODO
+  }
+
+  @Override
+  public CompletableFuture<Boolean> splitSwitch(boolean enabled, boolean drainSplits) {
+    throw new UnsupportedOperationException("splitSwitch");
   }
 }

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncAdmin.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncAdmin.java
@@ -284,9 +284,7 @@ public class BigtableAsyncAdmin implements AsyncAdmin {
                             return getDescriptor(tbName).join();
                           } catch (CompletionException ex) {
                             if (ex.getCause() instanceof TableNotFoundException) {
-                              LOG.warn(
-                                  "Table not found while fetching details for %s",
-                                  ex, tbName.getNameAsString());
+                              // If table not found then remove it from the list.
                               return null;
                             }
                             throw ex;

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTableRegionLocator.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableAsyncTableRegionLocator.java
@@ -19,6 +19,7 @@ import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.core.IBigtableDataClient;
 import com.google.cloud.bigtable.hbase.AbstractBigtableRegionLocator;
 import com.google.cloud.bigtable.hbase.adapters.SampledRowKeysAdapter;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.apache.hadoop.hbase.HRegionLocation;
 import org.apache.hadoop.hbase.ServerName;
@@ -65,6 +66,21 @@ public class BigtableAsyncTableRegionLocator extends AbstractBigtableRegionLocat
   public CompletableFuture<HRegionLocation> getRegionLocation(
       byte[] row, int replicaId, boolean reload) {
     return getRegionLocation(row, reload);
+  }
+
+  @Override
+  public CompletableFuture<List<HRegionLocation>> getRegionLocations(byte[] row, boolean reload) {
+    throw new UnsupportedOperationException("getRegionLocations"); // TODO
+  }
+
+  @Override
+  public CompletableFuture<List<HRegionLocation>> getAllRegionLocations() {
+    throw new UnsupportedOperationException("getAllRegionLocations"); // TODO
+  }
+
+  @Override
+  public void clearRegionLocationCache() {
+    throw new UnsupportedOperationException("clearRegionLocationCache");
   }
 
   @Override

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/com/google/cloud/bigtable/hbase2_x/BigtableConnection.java
@@ -123,6 +123,11 @@ public class BigtableConnection extends AbstractBigtableConnection {
     return new BigtableTable(this, createAdapter(tableName));
   }
 
+  @Override
+  public void clearRegionLocationCache() {
+    throw new UnsupportedOperationException("clearRegionLocationCache");
+  }
+
   /* (non-Javadoc)
    * @see org.apache.hadoop.hbase.client.CommonConnection#getAllRegionInfos(org.apache.hadoop.hbase.TableName)
    */

--- a/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
+++ b/bigtable-hbase-2.x-parent/bigtable-hbase-2.x/src/main/java/org/apache/hadoop/hbase/client/BigtableAsyncConnection.java
@@ -150,6 +150,11 @@ public class BigtableAsyncConnection implements AsyncConnection, CommonConnectio
       }
 
       @Override
+      public AsyncAdminBuilder setRetryPauseForCQTBE(long l, TimeUnit timeUnit) {
+        return this;
+      }
+
+      @Override
       public AsyncAdminBuilder setOperationTimeout(long arg0, TimeUnit arg1) {
         return this;
       }
@@ -182,6 +187,11 @@ public class BigtableAsyncConnection implements AsyncConnection, CommonConnectio
 
       @Override
       public AsyncBufferedMutatorBuilder setWriteBufferSize(long arg0) {
+        return this;
+      }
+
+      @Override
+      public AsyncBufferedMutatorBuilder setMaxKeyValueSize(int i) {
         return this;
       }
 
@@ -225,6 +235,11 @@ public class BigtableAsyncConnection implements AsyncConnection, CommonConnectio
   }
 
   @Override
+  public boolean isClosed() {
+    return closed;
+  }
+
+  @Override
   public AsyncTableBuilder<AdvancedScanResultConsumer> getTableBuilder(TableName tableName) {
     return new AsyncTableBuilder<AdvancedScanResultConsumer>() {
 
@@ -252,6 +267,12 @@ public class BigtableAsyncConnection implements AsyncConnection, CommonConnectio
 
       @Override
       public AsyncTableBuilder<AdvancedScanResultConsumer> setRetryPause(long arg0, TimeUnit arg1) {
+        return this;
+      }
+
+      @Override
+      public AsyncTableBuilder<AdvancedScanResultConsumer> setRetryPauseForCQTBE(
+          long l, TimeUnit timeUnit) {
         return this;
       }
 
@@ -286,6 +307,11 @@ public class BigtableAsyncConnection implements AsyncConnection, CommonConnectio
   }
 
   @Override
+  public void clearRegionLocationCache() {
+    throw new UnsupportedOperationException("this ddoes not supported yet");
+  }
+
+  @Override
   public AsyncTableBuilder<ScanResultConsumer> getTableBuilder(
       TableName tableName, final ExecutorService ignored) {
     return new AsyncTableBuilder<ScanResultConsumer>() {
@@ -311,6 +337,12 @@ public class BigtableAsyncConnection implements AsyncConnection, CommonConnectio
 
       @Override
       public AsyncTableBuilder<ScanResultConsumer> setRetryPause(long arg0, TimeUnit arg1) {
+        return this;
+      }
+
+      @Override
+      public AsyncTableBuilder<ScanResultConsumer> setRetryPauseForCQTBE(
+          long l, TimeUnit timeUnit) {
         return this;
       }
 

--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,8 @@ limitations under the License.
         <checkerframework.version>2.5.2</checkerframework.version>
 
         <!-- hbase dependency versions -->
-        <hbase.version.1>1.4.9</hbase.version.1>
-        <hbase.version.2>2.1.4</hbase.version.2>
+        <hbase.version.1>1.4.10</hbase.version.1>
+        <hbase.version.2>2.2.0</hbase.version.2>
         <hbase.version>${hbase.version.1}</hbase.version>
         <hadoop.version>2.7.4</hadoop.version>
 


### PR DESCRIPTION
Latest version of Hbase-2.2.0([release note](https://apache.org/dist/hbase/2.2.0/RELEASENOTES.md)) has introduced new operations.

Some of the additive methods introduced in hbase 2.x:
```
BigtableAdmin#createTableAsync(TableDescriptor tableDescriptor)
BigtableAsyncAdmin#listTableDescriptors(List<TableName> list)
BigtableAsyncAdmin#restoreSnapshot(String s, boolean b, boolean b1)
BigtableAsyncAdmin#cloneSnapshot(String s, TableName tableName, boolean b)

BigtableAsyncTableRegionLocator#getRegionLocations(byte[] bytes, boolean b)
BigtableAsyncTableRegionLocator#getAllRegionLocations()
BigtableAsyncTableRegionLocator#clearRegionLocationCache()

BigtableConnection#clearRegionLocationCache()

BigtableAsyncConnection#isClosed()
BigtableAsyncConnection#setRetryPauseForCQTBE(long l, TimeUnit timeUnit)
BigtableAsyncConnection#setMaxKeyValueSize(int i)
BigtableAsyncConnection#clearRegionLocationCache()
```

After discussion, we came to a conclusion that we should implement these three methods(Other methods can be implemented based on usage and user request).

```
BigtableAdmin#createTableAsync(TableDescriptor tableDescriptor)
BigtableAsyncAdmin#listTableDescriptors(List<TableName> list)
BigtableAsyncConnection#isClosed()
```